### PR TITLE
Add clone traffic chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,3 +530,11 @@ Full documentation is available in the `docs/` folder:
 
 See [CHANGELOG.md](CHANGELOG.md) for release history and changes.
 Event schema details: [docs/event-normalization.md](docs/event-normalization.md)
+
+---
+
+## Clone traffic
+
+![Clone traffic](https://raw.githubusercontent.com/nikolareljin/stats/main/charts/vigilant-core.svg)
+
+_Updated daily. Total and unique cloners over the last 14 days._


### PR DESCRIPTION
## Summary

- Add the clone traffic SVG chart from nikolareljin/stats to the README.

## Validation

- Verified the stats SVG exists at charts/vigilant-core.svg before updating the README.
- Ran git diff --check for the README change.