### PR TITLE
feat(reasoning): relevance-aware AI context selection (0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to VigilantCore will be documented in this file.
 
+## [0.9.0] - 2026-06-18
+
+### Added
+
+- **Relevance-aware reasoning context** (`utils/context_selection.py`): a deterministic, dependency-free selection layer that decides which stored alerts are injected into the AI insight prompt, replacing the previous "dump the most recent alerts" behaviour. It splits candidates into two clearly-labeled tiers:
+  - **CURRENT & RELEVANT** — alerts within a freshness window *and* topically relevant to the monitoring question/subject (token coverage + aspect overlap).
+  - **HISTORICAL CONTEXT** — older alerts that share an *infrastructure* aspect with the question (power grid, flooding, transport, structural, communications, water), retained as background about persistent structural risk. For example, a power-grid failure during a past snow storm is kept when reasoning about grid risk in a summer storm, while a stale "12 inches of snow expected" forecast is excluded.
+- **Aspect taxonomy** mapping event keywords to event-type and infrastructure aspects, with `extract_aspects()` and `relevance_score()` helpers (reusing the shared `_tokenize`/`_jaccard` deduplication primitives).
+- **Context selection settings** in `AppConfig`: `context_fresh_window_hours` (24), `context_min_relevance` (0.12), `context_max_current` (20), `context_max_historical` (6), and `context_enable_historical` (true), all persisted via config load/save.
+- **Tests** (`tests/test_context_selection.py`) covering freshness filtering, off-topic exclusion, structural-history retention, the disabled-historical path, accurate `sources_used`, and timestamp edge cases.
+
+### Changed
+
+- **AI insight prompts** (`src/main.py`, `src/web_app.py`) now build context through the shared selector instead of a duplicated inline loop, widen the candidate pool to 200 so low-impact-but-structurally-relevant history can surface, and derive `sources_used` only from alerts actually used. The system prompt instructs the model to treat the HISTORICAL section strictly as background structural risk — never as current conditions — and to ignore data from a different season or event type than the question.
+
+### Fixed
+
+- **Stale-content pollution across runs**: alerts from a *previous* event no longer leak into the reasoning as current conditions on later runs; they only resurface as explicitly-labeled historical background when structurally relevant. Records are preserved in storage — irrelevant ones are simply not injected.
+
 ## [0.8.1] - 2026-03-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ cd vigilant-core
 ## Key Features
 
 - **AI-Powered Insights**: Ask specific monitoring questions and get AI-generated answers
+- **Relevance-Aware Reasoning Context**: Insight prompts only inject alerts that are fresh *and* on-topic for your question, while preserving older records that remain *structurally* relevant (e.g. past power-grid failures inform grid risk in a new storm). Stale or off-topic data — like leftover snow forecasts during a summer storm — no longer pollutes the reasoning. Tunable via `context_*` settings.
 - **Impact Scoring**: Every alert scored 1-10 for relevance and urgency
 - **Location-Aware**: Filter alerts by ZIP code, coordinates, or radius
 - **Automatic Local Discovery**: When you provide a ZIP code, automatically finds:

--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,7 @@ if str(ROOT_DIR) not in sys.path:
 from engine.monitor import MonitorEngine  # noqa: E402
 from utils import database  # noqa: E402
 from utils.config import AppConfig, config_path, load_config, save_config  # noqa: E402
+from utils.context_selection import build_context_text, select_context  # noqa: E402
 from utils.insight import (  # noqa: E402
     normalize_suggestions as _normalize_suggestions,
     normalize_suggestions_origin as _normalize_suggestions_origin,
@@ -28,7 +29,9 @@ def generate_insight(config: AppConfig) -> Optional[Dict]:
     if not config.question or not config.question.strip():
         return None
 
-    alerts = database.fetch_recent(50)
+    # Recency-ordered candidate pool: freshness drives CURRENT selection, so the
+    # pool must contain the newest alerts even if their impact score is low.
+    alerts = database.fetch_recent_by_time(200)
     if not alerts:
         return {
             "question": config.question,
@@ -39,22 +42,32 @@ def generate_insight(config: AppConfig) -> Optional[Dict]:
             "sources_used": [],
         }
 
-    # Build context from alerts
-    alert_summaries = []
-    sources_used = set()
-    for alert in alerts[:30]:
-        title = alert["title"] or ""
-        snippet = alert["snippet"] or ""
-        source = alert["source"] or "Unknown"
-        score = alert["impact_score"] or 0
-        prediction = alert["predictive_outcome"] or ""
-        sources_used.add(source)
-        alert_summaries.append(
-            f"- [{source}] (impact: {score}/10) {title}. {snippet[:200]}"
-            + (f" Prediction: {prediction}" if prediction else "")
-        )
+    # Select a relevance-aware context: fresh + on-topic alerts as CURRENT, and
+    # structurally relevant older alerts as HISTORICAL background. This keeps
+    # stale or off-topic data (e.g. snow forecasts during a summer storm) from
+    # polluting the reasoning while preserving causally useful history.
+    selection = select_context(
+        alerts,
+        question=config.question,
+        subject=config.subject,
+        fresh_window_hours=config.context_fresh_window_hours,
+        min_relevance=config.context_min_relevance,
+        max_current=config.context_max_current,
+        max_historical=config.context_max_historical,
+        enable_historical=config.context_enable_historical,
+    )
+    if selection.is_empty:
+        return {
+            "question": config.question,
+            "summary": "No relevant data available.",
+            "explanation": "No collected alerts are relevant to this question yet.",
+            "suggestions": [],
+            "suggestions_origin": "none",
+            "sources_used": [],
+        }
 
-    context = "\n".join(alert_summaries)
+    context = build_context_text(selection)
+    sources_used = selection.sources_used
 
     try:
         from ollama import Client as OllamaClient
@@ -81,13 +94,19 @@ def generate_insight(config: AppConfig) -> Optional[Dict]:
             f"You are an intelligence analyst. Based on the collected news and alerts about "
             f"'{config.subject}' in '{config.location_name}', answer the user's monitoring question. "
             f"Be concise, factual, and cite specific alerts when relevant. "
-            f"If asked about probability or likelihood, provide a percentage estimate with brief reasoning."
+            f"If asked about probability or likelihood, provide a percentage estimate with brief reasoning. "
+            f"The alerts are split into two groups. Treat 'CURRENT & RELEVANT ALERTS' as present-day "
+            f"conditions, and within that group ignore any item that pertains to a different season or "
+            f"event type than the question. Treat 'HISTORICAL CONTEXT' as background about past events: it "
+            f"is intentionally cross-event, so it may describe a different season or event type and should "
+            f"still be used to reason about persistent structural risks (e.g. a recurring power-grid "
+            f"weakness) — but never as current conditions, and never quote its forecasts or figures as "
+            f"present-day facts."
         )
 
         prompt_lines = [
             f"MONITORING QUESTION: {config.question}",
             "",
-            "RECENT ALERTS AND NEWS:",
             context,
             "",
             "Provide your response as JSON with these keys:",
@@ -136,7 +155,7 @@ def generate_insight(config: AppConfig) -> Optional[Dict]:
             "explanation": payload.get("explanation", ""),
             "suggestions": suggestions,
             "suggestions_origin": _normalize_suggestions_origin(payload.get("suggestions_origin"), suggestions),
-            "sources_used": list(sources_used)[:10],
+            "sources_used": sorted(sources_used)[:10],
         }
 
     except Exception as e:

--- a/src/web_app.py
+++ b/src/web_app.py
@@ -18,6 +18,7 @@ if str(ROOT_DIR) not in sys.path:
 from engine.monitor import MonitorEngine  # noqa: E402
 from utils import database  # noqa: E402
 from utils.config import AppConfig, config_path, load_config, save_config  # noqa: E402
+from utils.context_selection import build_context_text, select_context  # noqa: E402
 from utils.geo import detect_geo  # noqa: E402
 from utils.insight import (  # noqa: E402
     normalize_suggestions as _normalize_suggestions,
@@ -981,35 +982,47 @@ def api_insight() -> str:
     if not config.question or not config.question.strip():
         return jsonify({"has_question": False})
 
-    # Get recent alerts for context
-    alerts = database.fetch_recent(50)
+    # Recency-ordered candidate pool: freshness drives CURRENT selection, so the
+    # pool must contain the newest alerts even if their impact score is low.
+    alerts = database.fetch_recent_by_time(200)
     if not alerts:
         return jsonify({
             "has_question": True,
             "question": config.question,
             "summary": "No relevant data available.",
             "explanation": "No alerts have been collected yet. Check back after the monitoring system gathers data.",
-            "suggestions": [] if config.enable_ai_suggestions else [],
+            "suggestions": [],
             "suggestions_origin": "none",
             "sources_used": [],
         })
 
-    # Build context from alerts
-    alert_summaries = []
-    sources_used = set()
-    for alert in alerts[:30]:  # Use top 30 for context
-        title = alert["title"] or ""
-        snippet = alert["snippet"] or ""
-        source = alert["source"] or "Unknown"
-        score = alert["impact_score"] or 0
-        prediction = alert["predictive_outcome"] or ""
-        sources_used.add(source)
-        alert_summaries.append(
-            f"- [{source}] (impact: {score}/10) {title}. {snippet[:200]}"
-            + (f" Prediction: {prediction}" if prediction else "")
-        )
+    # Select a relevance-aware context: fresh + on-topic alerts as CURRENT, and
+    # structurally relevant older alerts as HISTORICAL background. This keeps
+    # stale or off-topic data (e.g. snow forecasts during a summer storm) from
+    # polluting the reasoning while preserving causally useful history.
+    selection = select_context(
+        alerts,
+        question=config.question,
+        subject=config.subject,
+        fresh_window_hours=config.context_fresh_window_hours,
+        min_relevance=config.context_min_relevance,
+        max_current=config.context_max_current,
+        max_historical=config.context_max_historical,
+        enable_historical=config.context_enable_historical,
+    )
+    if selection.is_empty:
+        return jsonify({
+            "has_question": True,
+            "question": config.question,
+            "summary": "No relevant data available.",
+            "explanation": "No collected alerts are relevant to this question yet.",
+            "suggestions": [],
+            "suggestions_origin": "none",
+            "sources_used": [],
+        })
 
-    context = "\n".join(alert_summaries)
+    context = build_context_text(selection)
+    sources_used = selection.sources_used
 
     # Use Ollama to generate insight
     try:
@@ -1042,13 +1055,19 @@ def api_insight() -> str:
             f"You are an intelligence analyst. Based on the collected news and alerts about "
             f"'{config.subject}' in '{config.location_name}', answer the user's monitoring question. "
             f"Be concise, factual, and cite specific alerts when relevant. "
-            f"If asked about probability or likelihood, provide a percentage estimate with brief reasoning."
+            f"If asked about probability or likelihood, provide a percentage estimate with brief reasoning. "
+            f"The alerts are split into two groups. Treat 'CURRENT & RELEVANT ALERTS' as present-day "
+            f"conditions, and within that group ignore any item that pertains to a different season or "
+            f"event type than the question. Treat 'HISTORICAL CONTEXT' as background about past events: it "
+            f"is intentionally cross-event, so it may describe a different season or event type and should "
+            f"still be used to reason about persistent structural risks (e.g. a recurring power-grid "
+            f"weakness) — but never as current conditions, and never quote its forecasts or figures as "
+            f"present-day facts."
         )
 
         prompt_lines = [
             f"MONITORING QUESTION: {config.question}",
             "",
-            "RECENT ALERTS AND NEWS:",
             context,
             "",
             "Provide your response as JSON with these keys:",
@@ -1102,7 +1121,7 @@ def api_insight() -> str:
             "explanation": payload.get("explanation", ""),
             "suggestions": suggestions,
             "suggestions_origin": _normalize_suggestions_origin(payload.get("suggestions_origin"), suggestions),
-            "sources_used": list(sources_used)[:10],
+            "sources_used": sorted(sources_used)[:10],
         })
 
     except Exception as e:

--- a/tests/test_config_persistence.py
+++ b/tests/test_config_persistence.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from utils.config import AppConfig, save_config
+from utils.config import AppConfig, load_config, save_config
 
 
 class ConfigPersistenceTests(unittest.TestCase):
@@ -34,6 +35,42 @@ class ConfigPersistenceTests(unittest.TestCase):
                 env_text = dot_env.read_text(encoding="utf-8")
                 self.assertIn("ENABLE_DUCKDUCKGO_SEARCH=false", env_text)
                 self.assertIn("LOW_BANDWIDTH_MODE=true", env_text)
+
+
+    def test_load_config_falls_back_on_invalid_context_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg_root = Path(tmpdir)
+            (cfg_root / "config.json").write_text(
+                json.dumps(
+                    {
+                        "subject": "Weather",
+                        "context_fresh_window_hours": "abc",
+                        "context_min_relevance": "not-a-number",
+                        "context_max_current": "xyz",
+                        "context_max_historical": None,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with patch("utils.config.config_dir", return_value=cfg_root):
+                cfg = load_config()
+            # Invalid numeric values fall back to defaults instead of crashing.
+            self.assertEqual(cfg.context_fresh_window_hours, 24.0)
+            self.assertEqual(cfg.context_min_relevance, 0.12)
+            self.assertEqual(cfg.context_max_current, 20)
+            self.assertEqual(cfg.context_max_historical, 6)
+
+    def test_load_config_parses_boolean_string_for_enable_historical(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg_root = Path(tmpdir)
+            (cfg_root / "config.json").write_text(
+                json.dumps({"subject": "Weather", "context_enable_historical": "false"}),
+                encoding="utf-8",
+            )
+            with patch("utils.config.config_dir", return_value=cfg_root):
+                cfg = load_config()
+            # "false" must disable the tier, not be read as truthy.
+            self.assertFalse(cfg.context_enable_historical)
 
 
 if __name__ == "__main__":

--- a/tests/test_context_selection.py
+++ b/tests/test_context_selection.py
@@ -1,0 +1,372 @@
+"""Tests for relevance-aware reasoning context selection."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from utils.context_selection import (
+    INFRASTRUCTURE_ASPECTS,
+    ScoredAlert,
+    _format_alert_line,
+    _sanitize_field,
+    build_context_text,
+    extract_aspects,
+    relevance_score,
+    select_context,
+)
+from utils.text_similarity import tokenize as _tokenize
+
+
+NOW = datetime(2026, 6, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _alert(title, snippet, when, *, source="Feed", impact=5, prediction=""):
+    """Build a dict alert with an event timestamp ``when`` hours before NOW."""
+    ts = (NOW - timedelta(hours=when)).isoformat().replace("+00:00", "Z")
+    return {
+        "title": title,
+        "snippet": snippet,
+        "source": source,
+        "impact_score": impact,
+        "predictive_outcome": prediction,
+        "event_timestamp_utc": ts,
+        "created_at": ts,
+    }
+
+
+# Fresh summer storm directly threatening the grid.
+SUMMER_STORM = _alert(
+    "Severe summer thunderstorm warning",
+    "Damaging winds and power outages possible across the area.",
+    impact=8,
+    when=2,
+)
+# Old winter snow forecast — off topic, no infrastructure overlap with a power
+# question. This is the "12 inches of snow" noise that must not pollute reasoning.
+SNOW_FORECAST = _alert(
+    "Winter storm: 12 inches of snow expected",
+    "Heavy snowfall and wintry conditions forecast; schools may close.",
+    impact=7,
+    when=24 * 150,  # ~5 months ago
+    source="SnowFeed",  # distinct source so drop-leak tests are meaningful
+)
+# Old snow-era grid failure — different event type, but shares the power_grid
+# infrastructure aspect, so it stays as structural history.
+SNOW_GRID_FAILURE = _alert(
+    "Power grid failures during January blizzard",
+    "Substation outages left thousands without electricity during the snow storm.",
+    impact=9,
+    when=24 * 151,
+)
+
+QUESTION = "How likely are power outages during this summer storm?"
+SUBJECT = "Power Outages"
+
+
+class AspectTests(unittest.TestCase):
+    def test_extract_power_aspect(self):
+        self.assertIn("power_grid", extract_aspects("widespread power outage"))
+
+    def test_extract_snow_aspect(self):
+        self.assertEqual(extract_aspects("12 inches of snow"), {"snow_ice"})
+
+    def test_infrastructure_subset(self):
+        self.assertIn("power_grid", INFRASTRUCTURE_ASPECTS)
+        self.assertNotIn("snow_ice", INFRASTRUCTURE_ASPECTS)
+
+    def test_sanitize_field_preserves_falsy_values(self):
+        # Falsy non-string values are meaningful (e.g. a numeric 0 code) and
+        # must not be silently dropped; only None becomes empty.
+        self.assertEqual(_sanitize_field(0), "0")
+        self.assertEqual(_sanitize_field(False), "False")
+        self.assertEqual(_sanitize_field(None), "")
+        self.assertEqual(_sanitize_field("ok"), "ok")
+
+    def test_relevance_prefers_on_topic(self):
+        q_tokens = _tokenize(f"{QUESTION} {SUBJECT}")
+        q_aspects = extract_aspects(f"{QUESTION} {SUBJECT}")
+        on_topic = relevance_score(q_tokens, q_aspects, SUMMER_STORM)
+        off_topic = relevance_score(q_tokens, q_aspects, SNOW_FORECAST)
+        self.assertGreater(on_topic, off_topic)
+
+
+class SelectContextTests(unittest.TestCase):
+    def _select(self, **kw):
+        return select_context(
+            [SUMMER_STORM, SNOW_FORECAST, SNOW_GRID_FAILURE],
+            question=QUESTION,
+            subject=SUBJECT,
+            now=NOW,
+            **kw,
+        )
+
+    def test_current_has_fresh_relevant_only(self):
+        sel = self._select()
+        current_titles = [a.alert["title"] for a in sel.current]
+        self.assertIn(SUMMER_STORM["title"], current_titles)
+        # Old alerts never appear as CURRENT — stale content cannot pollute.
+        self.assertNotIn(SNOW_FORECAST["title"], current_titles)
+        self.assertNotIn(SNOW_GRID_FAILURE["title"], current_titles)
+
+    def test_structurally_relevant_history_retained(self):
+        sel = self._select()
+        hist_titles = [a.alert["title"] for a in sel.historical]
+        # Grid failure shares the power_grid aspect -> kept as background.
+        self.assertIn(SNOW_GRID_FAILURE["title"], hist_titles)
+        # Pure snow forecast has no infrastructure overlap -> dropped entirely.
+        self.assertNotIn(SNOW_FORECAST["title"], hist_titles)
+        self.assertGreaterEqual(sel.dropped, 1)
+
+    def test_off_topic_snow_absent_from_rendered_context(self):
+        text = build_context_text(self._select())
+        self.assertIn("CURRENT", text)
+        self.assertIn("HISTORICAL", text)
+        self.assertIn(SNOW_GRID_FAILURE["title"], text)
+        self.assertNotIn("12 inches of snow", text)
+
+    def test_disable_historical_drops_structural(self):
+        sel = self._select(enable_historical=False)
+        self.assertEqual(sel.historical, [])
+
+    def test_sources_used_only_from_selected(self):
+        sel = select_context(
+            [SUMMER_STORM, SNOW_FORECAST, SNOW_GRID_FAILURE],
+            question=QUESTION,
+            subject=SUBJECT,
+            now=NOW,
+        )
+        # SNOW_FORECAST (source "SnowFeed") is dropped, so its source must not
+        # leak into sources_used; only sources of selected alerts appear.
+        self.assertEqual(sel.sources_used, {"Feed"})
+        self.assertNotIn("SnowFeed", sel.sources_used)
+
+
+class EmptyAndEdgeTests(unittest.TestCase):
+    def test_no_fresh_alerts_renders_placeholder(self):
+        sel = select_context(
+            [SNOW_GRID_FAILURE],
+            question=QUESTION,
+            subject=SUBJECT,
+            now=NOW,
+        )
+        self.assertEqual(sel.current, [])
+        text = build_context_text(sel)
+        self.assertIn("no fresh, on-topic alerts", text)
+
+    def test_sources_used_includes_unknown_for_missing_source(self):
+        ts = (NOW - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+        no_source = {
+            "title": "Power outage now",
+            "snippet": "Electricity down across the area.",
+            "source": "",
+            "impact_score": 6,
+            "predictive_outcome": "",
+            "event_timestamp_utc": ts,
+            "created_at": ts,
+        }
+        sel = select_context([no_source], question=QUESTION, subject=SUBJECT, now=NOW)
+        self.assertEqual(len(sel.current), 1)
+        # Rendered line falls back to "[Unknown]"; sources_used must agree.
+        self.assertEqual(sel.sources_used, {"Unknown"})
+
+    def test_sources_used_is_sanitized_and_capped(self):
+        ts = (NOW - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+        alert = {
+            "title": "Power outage now",
+            "snippet": "Electricity down across the area.",
+            "source": "Feed\nName " + "X" * 200,
+            "impact_score": 6,
+            "predictive_outcome": "",
+            "event_timestamp_utc": ts,
+            "created_at": ts,
+        }
+        sel = select_context([alert], question=QUESTION, subject=SUBJECT, now=NOW)
+        self.assertEqual(len(sel.current), 1)
+        (src,) = sel.sources_used
+        self.assertNotIn("\n", src)
+        self.assertLessEqual(len(src), 80)
+        # sources_used must match exactly what the rendered prompt line shows.
+        self.assertIn(f"[{src}]", build_context_text(sel))
+
+    def test_empty_question_falls_back_to_fresh_alerts(self):
+        # A question with no meaningful tokens must not drop everything; fresh
+        # alerts still populate CURRENT so the user gets the current situation.
+        sel = select_context(
+            [SUMMER_STORM, SNOW_GRID_FAILURE],
+            question="ok",  # too short to yield a meaningful token
+            subject="",
+            now=NOW,
+        )
+        current_titles = [a.alert["title"] for a in sel.current]
+        self.assertIn(SUMMER_STORM["title"], current_titles)
+
+    def test_within_window_future_alert_is_current(self):
+        # Small future skew (scheduled post / clock drift) still counts as fresh.
+        future = _alert(
+            "Power outage imminent",
+            "Electricity expected to fail across the area soon.",
+            impact=6,
+            when=-2,  # 2 hours in the future
+        )
+        sel = select_context([future], question=QUESTION, subject=SUBJECT, now=NOW)
+        self.assertEqual(len(sel.current), 1)
+
+    def test_far_future_alert_excluded(self):
+        # A wildly future-dated timestamp must not dominate CURRENT, nor count
+        # as past historical background.
+        far = _alert(
+            "Power maintenance scheduled",
+            "Planned electricity grid maintenance.",
+            impact=9,
+            when=-24 * 30,  # 30 days in the future
+        )
+        sel = select_context([far], question=QUESTION, subject=SUBJECT, now=NOW)
+        self.assertEqual(sel.current, [])
+        self.assertEqual(sel.historical, [])
+        self.assertGreaterEqual(sel.dropped, 1)
+
+    def test_out_of_range_knobs_are_clamped(self):
+        # Negative / out-of-range config values must not crash or misbehave.
+        sel = select_context(
+            [SUMMER_STORM, SNOW_GRID_FAILURE],
+            question=QUESTION,
+            subject=SUBJECT,
+            now=NOW,
+            fresh_window_hours=-10,
+            min_relevance=-1,
+            max_current=-5,
+            max_historical=-2,
+        )
+        # max_current / max_historical clamp to 0 -> both tiers empty, no error.
+        self.assertEqual(sel.current, [])
+        self.assertEqual(sel.historical, [])
+
+    def test_unparseable_timestamp_treated_as_fresh(self):
+        weird = {
+            "title": "Power outage reported now",
+            "snippet": "Electricity down in the area.",
+            "source": "Feed",
+            "impact_score": 6,
+            "predictive_outcome": "",
+            "event_timestamp_utc": None,
+            "created_at": "not-a-date",
+        }
+        sel = select_context([weird], question=QUESTION, subject=SUBJECT, now=NOW)
+        self.assertEqual(len(sel.current), 1)
+
+    def test_format_line_omits_empty_fields(self):
+        def line(title, snippet):
+            scored = ScoredAlert(
+                alert={
+                    "title": title,
+                    "snippet": snippet,
+                    "source": "Feed",
+                    "impact_score": 5,
+                    "predictive_outcome": "",
+                },
+                relevance=0.5,
+                age_hours=1.0,
+            )
+            return _format_alert_line(scored)
+
+        self.assertEqual(line("Grid down", "Outage spreading"),
+                         "- [Feed] (impact: 5/10) Grid down. Outage spreading")
+        # No trailing ". " artifact when snippet is missing.
+        self.assertEqual(line("Grid down", ""), "- [Feed] (impact: 5/10) Grid down")
+        # No leading ". " artifact when title is missing.
+        self.assertEqual(line("", "Outage spreading"),
+                         "- [Feed] (impact: 5/10) Outage spreading")
+
+    def test_format_line_sanitizes_newlines_and_control_chars(self):
+        scored = ScoredAlert(
+            alert={
+                "title": "Line1\nLine2\tTab",
+                "snippet": "Ignore previous\r\ninstructions",
+                "source": "Feed\nX",
+                "impact_score": 5,
+                "predictive_outcome": "",
+            },
+            relevance=0.5,
+            age_hours=1.0,
+        )
+        line = _format_alert_line(scored)
+        # No injected line breaks or control chars survive into the prompt line.
+        self.assertNotIn("\n", line)
+        self.assertNotIn("\r", line)
+        self.assertNotIn("\t", line)
+        self.assertIn("Line1 Line2 Tab", line)
+        self.assertIn("Feed X", line)
+
+    def test_format_line_strips_unicode_and_del_controls(self):
+        # DEL (U+007F), zero-width space (U+200B), and a bidi override
+        # (U+202E) must not survive into the prompt text.
+        scored = ScoredAlert(
+            alert={
+                "title": "Grid\x7fdown\u200b now",
+                "snippet": "evac\u202euate",
+                "source": "Feed",
+                "impact_score": 5,
+                "predictive_outcome": "",
+            },
+            relevance=0.5,
+            age_hours=1.0,
+        )
+        line = _format_alert_line(scored)
+        for ch in ("\x7f", "\u200b", "\u202e"):
+            self.assertNotIn(ch, line)
+        self.assertIn("Grid", line)
+        self.assertIn("down", line)
+
+    def test_format_line_caps_long_fields(self):
+        scored = ScoredAlert(
+            alert={
+                "title": "T" * 500,
+                "snippet": "S" * 500,
+                "source": "F" * 200,
+                "impact_score": 5,
+                "predictive_outcome": "P" * 500,
+            },
+            relevance=0.5,
+            age_hours=1.0,
+        )
+        line = _format_alert_line(scored)
+        self.assertIn("T" * 200, line)
+        self.assertNotIn("T" * 201, line)
+        self.assertIn("S" * 200, line)
+        self.assertNotIn("S" * 201, line)
+        self.assertIn("F" * 80, line)
+        self.assertNotIn("F" * 81, line)
+        self.assertIn("P" * 200, line)
+        self.assertNotIn("P" * 201, line)
+
+    def test_format_line_uses_normalized_impact(self):
+        # A missing/invalid impact_score renders as the normalized int (0), the
+        # same value used for ranking.
+        scored = ScoredAlert(
+            alert={
+                "title": "T",
+                "snippet": "S",
+                "source": "Feed",
+                "impact_score": None,
+                "predictive_outcome": "",
+            },
+            relevance=0.5,
+            age_hours=1.0,
+        )
+        self.assertIn("(impact: 0/10)", _format_alert_line(scored))
+
+    def test_historical_section_always_rendered(self):
+        # Only a fresh, on-topic alert -> no historical, but the section (with a
+        # placeholder) must still appear so the two-group prompt stays stable.
+        sel = select_context(
+            [SUMMER_STORM], question=QUESTION, subject=SUBJECT, now=NOW
+        )
+        self.assertEqual(sel.historical, [])
+        text = build_context_text(sel)
+        self.assertIn("HISTORICAL CONTEXT", text)
+        self.assertIn("no structurally relevant history", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sqlite_local_cache.py
+++ b/tests/test_sqlite_local_cache.py
@@ -119,6 +119,62 @@ class SQLiteLocalCacheTests(unittest.TestCase):
                     self.assertEqual(history_count, 0)
                     self.assertEqual(source_count, 0)
 
+    def test_fetch_recent_by_time_orders_by_recency(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_root = Path(tmpdir)
+            with patch("utils.database.data_dir", return_value=data_root):
+                database.init_db()
+                # Old but high-impact, vs. newer but low-impact.
+                database.insert_alert(
+                    url="https://example.com/old",
+                    title="Old high-impact event",
+                    snippet="",
+                    published_at=None,
+                    source="S",
+                    source_kind="rss",
+                    severity="high",
+                    confidence=0.5,
+                    event_timestamp_utc="2026-01-01T00:00:00Z",
+                    impact_score=10,
+                    predictive_outcome="",
+                    is_relevant=True,
+                    subject="x",
+                    location_name="y",
+                )
+                database.insert_alert(
+                    url="https://example.com/new",
+                    title="New low-impact event",
+                    snippet="",
+                    published_at=None,
+                    source="S",
+                    source_kind="rss",
+                    severity="low",
+                    confidence=0.5,
+                    event_timestamp_utc="2026-06-01T00:00:00Z",
+                    impact_score=1,
+                    predictive_outcome="",
+                    is_relevant=True,
+                    subject="x",
+                    location_name="y",
+                )
+                # Pin created_at so recency ordering is deterministic.
+                with database.connect() as conn:
+                    conn.execute(
+                        "UPDATE alerts SET created_at=? WHERE url=?",
+                        ("2026-01-01 00:00:00", "https://example.com/old"),
+                    )
+                    conn.execute(
+                        "UPDATE alerts SET created_at=? WHERE url=?",
+                        ("2026-06-01 00:00:00", "https://example.com/new"),
+                    )
+
+                by_time = database.fetch_recent_by_time(10)
+                by_impact = database.fetch_recent(10)
+                # Recency order surfaces the newest (low-impact) alert first;
+                # impact order would have dropped/deprioritized it.
+                self.assertEqual(by_time[0]["url"], "https://example.com/new")
+                self.assertEqual(by_impact[0]["url"], "https://example.com/old")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/utils/config.py
+++ b/utils/config.py
@@ -66,6 +66,12 @@ class AppConfig:
     enable_duckduckgo_search: bool = True
     enable_ai_suggestions: bool = True
     low_bandwidth_mode: bool = False
+    # Relevance-aware reasoning context controls.
+    context_fresh_window_hours: float = 24.0
+    context_min_relevance: float = 0.12
+    context_max_current: int = 20
+    context_max_historical: int = 6
+    context_enable_historical: bool = True
 
 
 def config_dir() -> Path:
@@ -94,6 +100,41 @@ def config_path() -> Path:
 
 def env_path() -> Path:
     return config_dir() / ".env"
+
+
+def _coerce_float(value: object, default: float) -> float:
+    """Parse a config value as float, falling back to ``default`` if invalid."""
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(value: object, default: int) -> int:
+    """Parse a config value as int, falling back to ``default`` if invalid."""
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_bool(value: object, default: bool) -> bool:
+    """Parse a config value as bool, recognizing common JSON string forms.
+
+    A bare ``bool("false")`` is ``True``, which is a footgun for user-edited
+    config.json, so accept the usual string spellings explicitly.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ("1", "true", "yes", "on"):
+            return True
+        if lowered in ("0", "false", "no", "off"):
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
 
 
 def load_config() -> AppConfig:
@@ -129,12 +170,12 @@ def load_config() -> AppConfig:
         latitude=data.get("latitude"),
         longitude=data.get("longitude"),
         radius_km=int(data.get("radius_km", 50)),
-        relax_location_filter=bool(data.get("relax_location_filter", False)),
-        prefer_light_model=bool(data.get("prefer_light_model", True)),
+        relax_location_filter=_coerce_bool(data.get("relax_location_filter", False), False),
+        prefer_light_model=_coerce_bool(data.get("prefer_light_model", True), True),
         insight_refresh_minutes=int(data.get("insight_refresh_minutes", 5)),
         rss_feeds=data.get("rss_feeds", []),
-        use_only_rss_feeds=bool(data.get("use_only_rss_feeds", False)),
-        disable_rss_fetch=bool(data.get("disable_rss_fetch", False)),
+        use_only_rss_feeds=_coerce_bool(data.get("use_only_rss_feeds", False), False),
+        disable_rss_fetch=_coerce_bool(data.get("disable_rss_fetch", False), False),
         polling_minutes=int(data.get("polling_minutes", 5)),
         news_api_key=data.get("news_api_key"),
         news_time_window_hours=int(data.get("news_time_window_hours", 6)),
@@ -146,9 +187,20 @@ def load_config() -> AppConfig:
         bing_search_endpoint=data.get("bing_search_endpoint"),
         bing_search_market=data.get("bing_search_market"),
         bing_search_safe=data.get("bing_search_safe"),
-        enable_duckduckgo_search=bool(data.get("enable_duckduckgo_search", True)),
-        enable_ai_suggestions=bool(data.get("enable_ai_suggestions", True)),
-        low_bandwidth_mode=bool(data.get("low_bandwidth_mode", False)),
+        enable_duckduckgo_search=_coerce_bool(data.get("enable_duckduckgo_search", True), True),
+        enable_ai_suggestions=_coerce_bool(data.get("enable_ai_suggestions", True), True),
+        low_bandwidth_mode=_coerce_bool(data.get("low_bandwidth_mode", False), False),
+        context_fresh_window_hours=_coerce_float(
+            data.get("context_fresh_window_hours", 24), 24.0
+        ),
+        context_min_relevance=_coerce_float(
+            data.get("context_min_relevance", 0.12), 0.12
+        ),
+        context_max_current=_coerce_int(data.get("context_max_current", 20), 20),
+        context_max_historical=_coerce_int(data.get("context_max_historical", 6), 6),
+        context_enable_historical=_coerce_bool(
+            data.get("context_enable_historical", True), True
+        ),
     )
     cfg.news_api_key = cfg.news_api_key or os.getenv("NEWS_API_KEY")
     cfg.display_timezone = cfg.display_timezone or _load_display_timezone_from_env()
@@ -200,6 +252,11 @@ def save_config(config: AppConfig) -> None:
         "enable_duckduckgo_search": config.enable_duckduckgo_search,
         "enable_ai_suggestions": config.enable_ai_suggestions,
         "low_bandwidth_mode": config.low_bandwidth_mode,
+        "context_fresh_window_hours": config.context_fresh_window_hours,
+        "context_min_relevance": config.context_min_relevance,
+        "context_max_current": config.context_max_current,
+        "context_max_historical": config.context_max_historical,
+        "context_enable_historical": config.context_enable_historical,
     }
     config_path().write_text(json.dumps(data, indent=2), encoding="utf-8")
     env_lines = []

--- a/utils/context_selection.py
+++ b/utils/context_selection.py
@@ -1,0 +1,569 @@
+"""Relevance-aware reasoning context selection for VigilantCore.
+
+The insight pipeline historically dumped every recent alert into the LLM prompt.
+That pollutes reasoning in three ways:
+
+1. **Stale content** — alerts from a *past* event (e.g. last winter's storm) linger
+   in the local cache and keep getting injected on later runs.
+2. **Off-topic bias** — data for a different event type leaks into the answer
+   (e.g. expected snowfall inches surfacing during a *summer* storm question).
+3. **Lost causal history** — naively dropping all old data also discards records
+   that remain *structurally* relevant (e.g. a power-grid failure during a snow
+   storm is informative when reasoning about grid risk in a summer storm).
+
+This module selects context deterministically and offline (no extra deps) by
+splitting candidate alerts into two clearly-labeled tiers:
+
+* **CURRENT** — fresh (within a window) *and* topically relevant to the question.
+* **HISTORICAL** — old, but sharing an *infrastructure* aspect with the question,
+  retained as background about persistent structural risk (never current fact).
+
+Nothing is deleted from storage; irrelevant records are simply not injected.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterable, Optional
+
+# Shared tokenizer/similarity primitives, so the notion of "a meaningful token"
+# stays consistent across deduplication and context selection.
+from .text_similarity import jaccard as _jaccard, tokenize as _tokenize
+
+__all__ = [
+    "ContextSelection",
+    "ScoredAlert",
+    "ASPECT_KEYWORDS",
+    "INFRASTRUCTURE_ASPECTS",
+    "extract_aspects",
+    "relevance_score",
+    "select_context",
+    "build_context_text",
+]
+
+
+# ---------------------------------------------------------------------------
+# Aspect taxonomy
+# ---------------------------------------------------------------------------
+# Aspects describe *what an alert is about*. Event-type aspects (storm, snow_ice,
+# heat, wind) discriminate topic/season; infrastructure aspects describe systems
+# that can fail across many event types and are therefore causally reusable.
+
+ASPECT_KEYWORDS: dict[str, frozenset[str]] = {
+    "power_grid": frozenset(
+        {
+            "power",
+            "grid",
+            "electric",
+            "electrical",
+            "electricity",
+            "outage",
+            "outages",
+            "blackout",
+            "blackouts",
+            "substation",
+            "transformer",
+            "utility",
+            "utilities",
+            "voltage",
+            "powerline",
+            "powerlines",
+        }
+    ),
+    "flooding": frozenset(
+        {
+            "flood",
+            "flooding",
+            "floods",
+            "flash",
+            "inundation",
+            "overflow",
+            "surge",
+            "levee",
+            "levees",
+            "dam",
+            "waterlogged",
+        }
+    ),
+    "transport": frozenset(
+        {
+            "road",
+            "roads",
+            "traffic",
+            "highway",
+            "highways",
+            "transit",
+            "rail",
+            "railway",
+            "flight",
+            "flights",
+            "airport",
+            "bridge",
+            "bridges",
+            "closure",
+            "closures",
+            "detour",
+        }
+    ),
+    "structural": frozenset(
+        {
+            "building",
+            "buildings",
+            "collapse",
+            "collapsed",
+            "roof",
+            "roofs",
+            "infrastructure",
+            "structural",
+            "damage",
+            "debris",
+        }
+    ),
+    "communications": frozenset(
+        {
+            "cell",
+            "cellular",
+            "network",
+            "internet",
+            "communication",
+            "communications",
+            "signal",
+            "phone",
+            "telecom",
+            "broadband",
+        }
+    ),
+    "water": frozenset(
+        {
+            "water",
+            "sewage",
+            "sewer",
+            "sanitation",
+            "supply",
+            "contamination",
+            "drinking",
+            "boil",
+        }
+    ),
+    # Event-type aspects (not infrastructure) — used for topical/seasonal matching.
+    "storm": frozenset(
+        {
+            "storm",
+            "storms",
+            "thunderstorm",
+            "thunder",
+            "lightning",
+            "hail",
+            "squall",
+            "severe",
+        }
+    ),
+    "wind": frozenset(
+        {
+            "wind",
+            "winds",
+            "gust",
+            "gusts",
+            "gale",
+            "tornado",
+            "hurricane",
+            "cyclone",
+            "downburst",
+            "typhoon",
+        }
+    ),
+    "heat": frozenset(
+        {
+            "heat",
+            "heatwave",
+            "hot",
+            "temperature",
+            "drought",
+            "wildfire",
+            "wildfires",
+            "fire",
+            "summer",
+        }
+    ),
+    "snow_ice": frozenset(
+        {
+            "snow",
+            "snowfall",
+            "snowstorm",
+            "ice",
+            "icy",
+            "blizzard",
+            "freeze",
+            "freezing",
+            "frost",
+            "sleet",
+            "winter",
+            "wintry",
+            "inches",
+        }
+    ),
+}
+
+# Aspects that describe systems which can fail across event types. Sharing one of
+# these between a past event and the current question is what makes old records
+# *structurally* relevant rather than just stale noise.
+INFRASTRUCTURE_ASPECTS: frozenset[str] = frozenset(
+    {"power_grid", "flooding", "transport", "structural", "communications", "water"}
+)
+
+
+def _aspects_from_tokens(tokens: set[str]) -> set[str]:
+    """Map an already-computed token set to its aspect labels."""
+    if not tokens:
+        return set()
+    return {
+        aspect for aspect, keywords in ASPECT_KEYWORDS.items() if tokens & keywords
+    }
+
+
+def extract_aspects(text: str) -> set[str]:
+    """Return the set of aspect labels whose keywords appear in ``text``."""
+    return _aspects_from_tokens(_tokenize(text))
+
+
+# ---------------------------------------------------------------------------
+# Alert access helpers (work for sqlite3.Row and plain dict/mapping)
+# ---------------------------------------------------------------------------
+
+def _get(alert: Any, key: str, default: Any = None) -> Any:
+    try:
+        value = alert[key]
+    except (KeyError, IndexError, TypeError):
+        return default
+    return default if value is None else value
+
+
+def _alert_text(alert: Any) -> str:
+    parts = [
+        str(_get(alert, "title", "")),
+        str(_get(alert, "snippet", "")),
+        str(_get(alert, "predictive_outcome", "")),
+    ]
+    return " ".join(p for p in parts if p)
+
+
+def _parse_dt(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    # SQLite CURRENT_TIMESTAMP uses "YYYY-MM-DD HH:MM:SS" (UTC, no tz marker).
+    candidate = text.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(candidate)
+    except ValueError:
+        try:
+            dt = datetime.strptime(text, "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _alert_time(alert: Any) -> Optional[datetime]:
+    # Prefer the real-world event time; fall back to the row's ingestion time.
+    return _parse_dt(_get(alert, "event_timestamp_utc")) or _parse_dt(
+        _get(alert, "created_at")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def relevance_score(
+    question_tokens: set[str],
+    question_aspects: set[str],
+    alert: Any,
+) -> float:
+    """Topical relevance of ``alert`` to the question, in ``[0.0, 1.0]``.
+
+    Combines how much of the question's vocabulary the alert covers with how
+    much its aspect profile overlaps the question's. Coverage is weighted higher
+    than raw Jaccard so a short, on-point question is not penalised for brevity.
+    """
+    alert_tokens = _tokenize(_alert_text(alert))
+    return _relevance_from_parts(
+        question_tokens, question_aspects, alert_tokens, _aspects_from_tokens(alert_tokens)
+    )
+
+
+def _relevance_from_parts(
+    question_tokens: set[str],
+    question_aspects: set[str],
+    alert_tokens: set[str],
+    alert_aspects: set[str],
+) -> float:
+    """Relevance score from pre-computed token/aspect sets (no re-tokenizing)."""
+    if not alert_tokens:
+        return 0.0
+    if question_tokens:
+        coverage = len(question_tokens & alert_tokens) / len(question_tokens)
+    else:
+        coverage = 0.0
+    token_jaccard = _jaccard(question_tokens, alert_tokens)
+    aspect_jaccard = _jaccard(question_aspects, alert_aspects) if question_aspects else 0.0
+    return 0.5 * coverage + 0.2 * token_jaccard + 0.3 * aspect_jaccard
+
+
+@dataclass
+class ScoredAlert:
+    """An alert paired with the signals used to place it in a context tier."""
+
+    alert: Any
+    relevance: float
+    age_hours: Optional[float]
+    aspects: set[str] = field(default_factory=set)
+
+    @property
+    def impact(self) -> int:
+        try:
+            return int(_get(self.alert, "impact_score", 0) or 0)
+        except (TypeError, ValueError):
+            return 0
+
+
+def _recency_key(scored: "ScoredAlert") -> float:
+    """Sort value for recency (higher = more recent), clamping future ages.
+
+    A future-dated alert (negative age) is clamped to "now" so that a skewed or
+    scheduled timestamp far in the future cannot sort ahead of genuine
+    present-time alerts.
+    """
+    if scored.age_hours is None:
+        return 0.0
+    return -max(0.0, scored.age_hours)
+
+
+@dataclass
+class ContextSelection:
+    """Result of splitting candidate alerts into reasoning tiers."""
+
+    current: list[ScoredAlert] = field(default_factory=list)
+    historical: list[ScoredAlert] = field(default_factory=list)
+    dropped: int = 0
+    sources_used: set[str] = field(default_factory=set)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.current and not self.historical
+
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+
+def select_context(
+    alerts: Iterable[Any],
+    *,
+    question: str,
+    subject: str = "",
+    now: Optional[datetime] = None,
+    fresh_window_hours: float = 24.0,
+    min_relevance: float = 0.12,
+    max_current: int = 20,
+    max_historical: int = 6,
+    enable_historical: bool = True,
+) -> ContextSelection:
+    """Split ``alerts`` into CURRENT and HISTORICAL reasoning tiers.
+
+    * CURRENT  — fresh AND relevance >= ``min_relevance`` to
+      ``question``/``subject``. Freshness is a +/- window around ``now``: an age
+      within ``[-fresh_window_hours, fresh_window_hours]`` counts as fresh, so a
+      small amount of future skew (scheduled posts, feed clock drift) is allowed
+      while wildly future-dated timestamps are not. Alerts with an unparseable
+      timestamp are treated as fresh.
+    * HISTORICAL — genuinely past alerts older than the window that share an
+      infrastructure aspect with the question (structurally relevant), capped
+      and ranked by impact.
+
+    Alerts that are neither fresh-and-relevant nor structurally relevant (and
+    far-future timestamps) are dropped (counted, never deleted from storage).
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+
+    # Defensive normalization: these knobs can come straight from a user-edited
+    # config.json, so clamp them to sane ranges before use.
+    fresh_window_hours = max(0.0, float(fresh_window_hours))
+    min_relevance = min(1.0, max(0.0, float(min_relevance)))
+    max_current = max(0, int(max_current))
+    max_historical = max(0, int(max_historical))
+
+    question_text = f"{question or ''} {subject or ''}".strip()
+    q_tokens = _tokenize(question_text)
+    q_aspects = extract_aspects(question_text)
+    q_infra = q_aspects & INFRASTRUCTURE_ASPECTS
+    # With no usable question signal (empty/very short/all-stopword input) every
+    # alert scores 0, which would wrongly empty the CURRENT tier. Fall back to
+    # recency: include all fresh alerts so the user still sees what's happening.
+    has_question_signal = bool(q_tokens or q_aspects)
+
+    current: list[ScoredAlert] = []
+    historical: list[ScoredAlert] = []
+    dropped = 0
+
+    for alert in alerts:
+        dt = _alert_time(alert)
+        age_hours = (now - dt).total_seconds() / 3600.0 if dt is not None else None
+        # Tokenize once per alert and reuse for both relevance and aspects.
+        alert_tokens = _tokenize(_alert_text(alert))
+        aspects = _aspects_from_tokens(alert_tokens)
+        relevance = _relevance_from_parts(q_tokens, q_aspects, alert_tokens, aspects)
+        scored = ScoredAlert(
+            alert=alert, relevance=relevance, age_hours=age_hours, aspects=aspects
+        )
+
+        # Freshness is a +/- window around "now". A little future skew (scheduled
+        # posts, feed clock drift) still counts as current, but a wildly
+        # future-dated timestamp is anomalous: it is neither fresh nor eligible
+        # as past historical background, so it is dropped rather than allowed to
+        # dominate the CURRENT tier. Unparseable timestamps are treated as fresh.
+        if age_hours is None:
+            is_fresh, is_past = True, False
+        else:
+            is_fresh = -fresh_window_hours <= age_hours <= fresh_window_hours
+            is_past = age_hours > 0.0
+
+        if is_fresh and (not has_question_signal or relevance >= min_relevance):
+            current.append(scored)
+            continue
+
+        # Genuinely older past alerts: keep only if structurally relevant.
+        structurally_relevant = bool(q_infra and (aspects & q_infra))
+        if enable_historical and is_past and not is_fresh and structurally_relevant:
+            historical.append(scored)
+        else:
+            dropped += 1
+
+    # CURRENT: most relevant first, then impact, then most recent. Future-dated
+    # ages are clamped to "now" so they cannot sort ahead of present alerts.
+    current.sort(
+        key=lambda s: (s.relevance, s.impact, _recency_key(s)),
+        reverse=True,
+    )
+    # HISTORICAL: highest impact first, then most relevant, then most recent.
+    historical.sort(
+        key=lambda s: (s.impact, s.relevance, _recency_key(s)),
+        reverse=True,
+    )
+
+    dropped += max(0, len(current) - max_current)
+    dropped += max(0, len(historical) - max_historical)
+    current = current[:max_current]
+    historical = historical[:max_historical]
+
+    # Use the same sanitized/capped source label as the rendered line so
+    # sources_used never disagrees with what actually appears in the prompt.
+    sources_used: set[str] = {_clean_source(s.alert) for s in (*current, *historical)}
+
+    return ContextSelection(
+        current=current,
+        historical=historical,
+        dropped=dropped,
+        sources_used=sources_used,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _sanitize_field(value: Any) -> str:
+    """Collapse a feed field to safe single-line text for the prompt.
+
+    Upstream feeds can carry newlines and non-printable characters (ASCII
+    controls, DEL, and Unicode format/control characters such as zero-width or
+    bidirectional marks); left intact they break the bullet structure and let
+    injected text masquerade as separate prompt lines/instructions. Replace any
+    non-printable character (everything except a regular space) with a space and
+    collapse whitespace so each item stays on one clean line.
+    """
+    raw = "" if value is None else str(value)
+    text = "".join(ch if ch.isprintable() else " " for ch in raw)
+    return _WHITESPACE_RE.sub(" ", text).strip()
+
+
+# Per-field caps keep a single feed item from ballooning the prompt (latency,
+# cost, context-window pressure) if an upstream source returns very long text.
+_MAX_SOURCE = 80
+_MAX_TITLE = 200
+_MAX_SNIPPET = 200
+_MAX_PREDICTION = 200
+
+
+def _clean_source(alert: Any) -> str:
+    """Sanitized, capped source label with an "Unknown" fallback.
+
+    Used for both the rendered alert line and ``sources_used`` so the two never
+    disagree (no unclean or over-long source leaking into the API/UI).
+    """
+    return _sanitize_field(_get(alert, "source", "Unknown"))[:_MAX_SOURCE] or "Unknown"
+
+
+def _format_alert_line(scored: ScoredAlert, *, with_date: bool = False) -> str:
+    alert = scored.alert
+    source = _clean_source(alert)
+    title = _sanitize_field(_get(alert, "title", ""))[:_MAX_TITLE]
+    snippet = _sanitize_field(_get(alert, "snippet", ""))[:_MAX_SNIPPET]
+    # Use the normalized impact (same value used for ranking; always an int).
+    score = scored.impact
+    prediction = _sanitize_field(_get(alert, "predictive_outcome", ""))[:_MAX_PREDICTION]
+
+    prefix = ""
+    if with_date:
+        dt = _alert_time(alert)
+        if dt is not None:
+            prefix = f"({dt.date().isoformat()}) "
+
+    # Join only the non-empty pieces so a missing title or snippet never leaves
+    # a ". " artifact in the text that gets fed straight into the LLM prompt.
+    body = ". ".join(part for part in (title, snippet) if part)
+    line = f"- {prefix}[{source}] (impact: {score}/10)"
+    if body:
+        line += f" {body}"
+    if prediction:
+        line += f" Prediction: {prediction}"
+    return line
+
+
+def build_context_text(selection: ContextSelection) -> str:
+    """Render a selection into the two labeled sections used in the prompt."""
+    sections: list[str] = []
+
+    sections.append("CURRENT & RELEVANT ALERTS (fresh, on-topic):")
+    if selection.current:
+        sections.extend(_format_alert_line(s) for s in selection.current)
+    else:
+        sections.append("- (no fresh, on-topic alerts for this question)")
+
+    # Always emit the HISTORICAL section (with a placeholder when empty) so the
+    # two-group structure promised by the system prompt stays consistent.
+    sections.append("")
+    sections.append(
+        "HISTORICAL CONTEXT — past events that may be STRUCTURALLY relevant "
+        "(NOT current conditions; do not treat any forecast or figure here as "
+        "present-day fact):"
+    )
+    if selection.historical:
+        sections.extend(
+            _format_alert_line(s, with_date=True) for s in selection.historical
+        )
+    else:
+        sections.append("- (no structurally relevant history for this question)")
+
+    return "\n".join(sections)

--- a/utils/database.py
+++ b/utils/database.py
@@ -317,20 +317,38 @@ def _insert_source_metadata(
         )
 
 
+_ALERT_SELECT_COLUMNS: str = (
+    "id, url, title, snippet, published_at, source, "
+    "source_kind, severity, confidence, event_timestamp_utc, "
+    "location_zip_code, location_latitude, location_longitude, "
+    "impact_score, predictive_outcome, is_relevant, subject, location_name, "
+    "created_at"
+)
+
+
 def fetch_recent(limit: int = 200) -> List[sqlite3.Row]:
+    """Fetch alerts ranked by impact then recency (for ranked display lists)."""
     with connect() as conn:
         cur = conn.execute(
-            """
-            SELECT id, url, title, snippet, published_at, source,
-                   source_kind,
-                   severity, confidence, event_timestamp_utc,
-                   location_zip_code, location_latitude, location_longitude,
-                   impact_score, predictive_outcome, is_relevant, subject, location_name,
-                   created_at
-            FROM alerts
-            ORDER BY impact_score DESC, created_at DESC
-            LIMIT ?
-            """,
+            f"SELECT {_ALERT_SELECT_COLUMNS} FROM alerts "
+            "ORDER BY impact_score DESC, created_at DESC LIMIT ?",
+            (limit,),
+        )
+        return list(cur.fetchall())
+
+
+def fetch_recent_by_time(limit: int = 200) -> List[sqlite3.Row]:
+    """Fetch alerts ordered by recency (newest first).
+
+    Used to build the candidate pool for relevance-aware context selection,
+    where freshness is what matters: ordering by impact (as ``fetch_recent``
+    does) can drop low-impact but very recent alerts from a capped pool and
+    starve the CURRENT tier of genuinely current context.
+    """
+    with connect() as conn:
+        cur = conn.execute(
+            f"SELECT {_ALERT_SELECT_COLUMNS} FROM alerts "
+            "ORDER BY created_at DESC, impact_score DESC LIMIT ?",
             (limit,),
         )
         return list(cur.fetchall())

--- a/utils/event_deduplication.py
+++ b/utils/event_deduplication.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-import re
 from typing import Iterable
+
+from .text_similarity import jaccard as _jaccard, tokenize as _tokenize
 
 
 SOURCE_KIND_PRIORITY = {
@@ -25,27 +26,6 @@ _TITLE_PLACEHOLDERS = {
     "untitled",
     "(untitled)",
 }
-
-_WORD_RE = re.compile(r"[a-z0-9]+")
-_STOPWORDS = {
-    "a",
-    "an",
-    "and",
-    "at",
-    "by",
-    "for",
-    "from",
-    "in",
-    "into",
-    "is",
-    "of",
-    "on",
-    "or",
-    "the",
-    "to",
-    "with",
-}
-
 
 @dataclass
 class DeduplicatedEvent:
@@ -82,14 +62,6 @@ def _to_utc_datetime(value: str | None) -> datetime | None:
         return None
 
 
-def _tokenize(text: str) -> set[str]:
-    return {
-        token
-        for token in _WORD_RE.findall((text or "").lower())
-        if len(token) >= 3 and token not in _STOPWORDS
-    }
-
-
 def _title_fingerprint(title: str) -> str:
     tokens = sorted(_tokenize(title))
     if not tokens:
@@ -103,16 +75,6 @@ def _normalize_title_for_match(title: str) -> str:
     if lowered in _TITLE_PLACEHOLDERS:
         return ""
     return raw
-
-
-def _jaccard(left: set[str], right: set[str]) -> float:
-    if not left and not right:
-        return 1.0
-    if not left or not right:
-        return 0.0
-    overlap = left & right
-    union = left | right
-    return len(overlap) / len(union)
 
 
 def _is_overlap(

--- a/utils/text_similarity.py
+++ b/utils/text_similarity.py
@@ -1,0 +1,51 @@
+"""Shared lightweight text-similarity primitives.
+
+Public helpers used by both the event-deduplication engine and the
+relevance-aware context selector, so neither module has to reach into the
+other's private internals. Keeping these in one place also guarantees both use
+the same notion of a "meaningful token".
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["tokenize", "jaccard"]
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "at",
+    "by",
+    "for",
+    "from",
+    "in",
+    "into",
+    "is",
+    "of",
+    "on",
+    "or",
+    "the",
+    "to",
+    "with",
+}
+
+
+def tokenize(text: str) -> set[str]:
+    """Lowercase word tokens of length >= 3 with common stopwords removed."""
+    return {
+        token
+        for token in _WORD_RE.findall((text or "").lower())
+        if len(token) >= 3 and token not in _STOPWORDS
+    }
+
+
+def jaccard(left: set[str], right: set[str]) -> float:
+    """Jaccard similarity of two token sets (1.0 when both are empty)."""
+    if not left and not right:
+        return 1.0
+    if not left or not right:
+        return 0.0
+    return len(left & right) / len(left | right)


### PR DESCRIPTION
## Summary

Replaces the "dump the most recent alerts" behaviour in the AI insight pipeline with a deterministic, dependency-free **relevance-aware context selection** layer. This eliminates biased reasoning caused by stale or off-topic data while preserving genuinely useful history.

### Problem

Both insight paths (`src/main.py:generate_insight`, `src/web_app.py:api_insight`) built the model context by fetching the most recent alerts and injecting **all** of them, with no filtering by recency-window, topical relevance, or causal relevance. Consequences:

1. **Stale-content pollution** — on a later run, alerts from a *previous* event (e.g. last winter's storm) lingered in the local cache and were re-injected as if current.
2. **Off-topic bias** — data for a different event type leaked in (e.g. expected snowfall inches surfacing during a *summer* storm question).
3. **Lost causal history** — naively dropping old data would also discard records that remain *structurally* relevant (e.g. a power-grid failure during a snow storm is informative when reasoning about grid risk in a summer storm).

### Solution

New `utils/context_selection.py` splits candidate alerts into two clearly-labeled tiers before prompting:

- **CURRENT & RELEVANT** — fresh (within `context_fresh_window_hours`) **and** topically relevant to the question/subject (token coverage + aspect overlap).
- **HISTORICAL CONTEXT** — older alerts that share an **infrastructure aspect** with the question (power grid, flooding, transport, structural, communications, water), retained as background about persistent structural risk and explicitly flagged as *not current conditions*.

Everything else is dropped (counted, never deleted from storage — records are preserved, just not injected). The system prompt now instructs the model to treat HISTORICAL strictly as background and to ignore data from a different season/event type than the question.

### Changes

- `utils/context_selection.py` — aspect taxonomy, relevance scoring, tiered selection, prompt rendering (reuses shared `_tokenize`/`_jaccard`).
- `src/main.py`, `src/web_app.py` — wired through the shared selector (removes duplicated inline loop), candidate pool widened to 200, `sources_used` derived only from selected alerts.
- `utils/config.py` — new `context_*` settings with load/save persistence.
- `tests/test_context_selection.py` — 11 tests covering freshness, off-topic exclusion, structural-history retention, disabled-historical, `sources_used`, and timestamp edge cases.
- `CHANGELOG.md` (`0.9.0`), `README.md` feature note.

### Tuning knobs (`AppConfig`)

| Setting | Default | Purpose |
|---|---|---|
| `context_fresh_window_hours` | 24 | What counts as "current" |
| `context_min_relevance` | 0.12 | Topical relevance threshold for CURRENT |
| `context_max_current` | 20 | Cap on current-tier alerts |
| `context_max_historical` | 6 | Cap on historical-tier alerts |
| `context_enable_historical` | true | Toggle structural-history retention |

### Testing

`python -m unittest discover -s tests -p "test_*.py"` — **61 passed** (11 new).

### Release

Targets `0.9.0` (minor / feature). Merging to `main` triggers the auto-tag-release workflow. Marked **draft** pending review.

> Note: the unrelated `scripts/script-helpers` submodule pointer bump present in the working tree was intentionally left out of this branch.
