### PR TITLE
feat(platform): plugin kernel, EmergencyEvent contract, and mesh store-and-forward (Phase 1)

### DIFF
--- a/contracts/__init__.py
+++ b/contracts/__init__.py
@@ -1,0 +1,32 @@
+"""Shared platform contracts for VigilantCore.
+
+The :class:`EmergencyEvent` here is the single source of truth for the event
+shape exchanged between the Python hub, the dashboard, the MQTT bus, and the
+Rust/Go edge daemons. Importing from ``contracts`` (rather than reaching into
+``utils``) is the supported way for plugins and external components to speak the
+platform's language.
+"""
+
+from __future__ import annotations
+
+from .event import (
+    EmergencyEvent,
+    HAZARD_TYPES,
+    SCHEMA_VERSION,
+    SEVERITIES,
+    infer_hazard_type,
+)
+from .ids import new_ulid
+from .schema import load_schema
+from . import trust
+
+__all__ = [
+    "EmergencyEvent",
+    "HAZARD_TYPES",
+    "SEVERITIES",
+    "SCHEMA_VERSION",
+    "infer_hazard_type",
+    "new_ulid",
+    "load_schema",
+    "trust",
+]

--- a/contracts/emergency_event.schema.json
+++ b/contracts/emergency_event.schema.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vigilant-core/contracts/emergency_event.schema.json",
+  "title": "EmergencyEvent",
+  "description": "Canonical cross-node emergency event contract for the VigilantCore platform.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_id",
+    "title",
+    "hazard_type",
+    "severity",
+    "confidence",
+    "impact_score",
+    "timestamp_utc"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "2.0"
+    },
+    "event_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable ULID used for cross-node dedup."
+    },
+    "origin_node_id": {
+      "type": ["string", "null"],
+      "description": "Node that first observed/produced the event."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "hazard_type": {
+      "type": "string",
+      "enum": [
+        "storm",
+        "hurricane",
+        "tornado",
+        "fire",
+        "flood",
+        "earthquake",
+        "outage",
+        "hazmat",
+        "conflict",
+        "transport",
+        "medical",
+        "other"
+      ]
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "impact_score": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10
+    },
+    "timestamp_utc": {
+      "type": "string",
+      "description": "When this event record was observed/created (ISO-8601 UTC)."
+    },
+    "event_timestamp_utc": {
+      "type": ["string", "null"],
+      "description": "When the underlying hazard occurred (ISO-8601 UTC)."
+    },
+    "location": {
+      "type": "object",
+      "properties": {
+        "name": {"type": ["string", "null"]},
+        "zip_code": {"type": ["string", "null"]},
+        "latitude": {"type": ["number", "null"]},
+        "longitude": {"type": ["number", "null"]},
+        "radius_km": {"type": ["number", "null"]},
+        "geohash": {"type": ["string", "null"]}
+      },
+      "additionalProperties": true
+    },
+    "summary": {"type": "string"},
+    "predictive_outcome": {"type": "string"},
+    "url": {"type": ["string", "null"]},
+    "sources": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "trust": {
+      "type": "string",
+      "enum": [
+        "untrusted",
+        "open_search",
+        "known_feed",
+        "authenticated_api",
+        "signed_node"
+      ]
+    },
+    "ttl_hops": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Remaining mesh hops; decremented on each forward (storm protection)."
+    },
+    "seen_nodes": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Nodes that have handled this event (loop prevention)."
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "kind": {"type": "string"},
+          "detail": {"type": "string"},
+          "status": {"type": "string"}
+        },
+        "additionalProperties": true
+      }
+    },
+    "signature": {
+      "type": ["string", "null"],
+      "description": "Optional Ed25519 signature over the canonical event (Phase 4)."
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -1,0 +1,230 @@
+"""The canonical ``EmergencyEvent`` contract shared across the platform.
+
+Every component — the ingest pipeline, the dashboard, the MQTT bus, and the
+low-power Rust/Go edge daemons — agrees on this one shape. It is a strict
+superset of the v1.0 normalized alert produced by
+``utils.event_normalization.normalize_event_payload`` (see ``from_normalized``),
+so existing alerts upgrade losslessly while new fields (stable ``event_id``,
+``origin_node_id``, ``hazard_type``, ``trust``, mesh ``ttl_hops``/``seen_nodes``,
+recommended ``actions``) enable cross-node propagation, routing, and trust.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional
+
+from . import trust as trust_tiers
+from .geohash import encode_optional
+from .ids import new_ulid
+
+SCHEMA_VERSION = "2.0"
+
+# Canonical hazard taxonomy. ``other`` is the catch-all; callers should prefer a
+# specific value so routing/geo-dedup can reason about event class.
+HAZARD_TYPES: tuple[str, ...] = (
+    "storm",
+    "hurricane",
+    "tornado",
+    "fire",
+    "flood",
+    "earthquake",
+    "outage",
+    "hazmat",
+    "conflict",
+    "transport",
+    "medical",
+    "other",
+)
+
+SEVERITIES: tuple[str, ...] = ("low", "medium", "high", "critical")
+
+# Keyword → hazard_type. First match wins; order matters (specific before generic).
+_HAZARD_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("hurricane", ("hurricane", "typhoon", "cyclone")),
+    ("tornado", ("tornado", "twister", "funnel cloud")),
+    ("fire", ("wildfire", "fire", "blaze", "burn")),
+    ("flood", ("flood", "flash flood", "storm surge", "inundation")),
+    ("earthquake", ("earthquake", "quake", "seismic", "aftershock")),
+    ("outage", ("power outage", "blackout", "grid", "outage")),
+    ("hazmat", ("hazmat", "chemical spill", "gas leak", "radiation", "toxic")),
+    ("conflict", ("shooting", "explosion", "attack", "shelling", "airstrike", "conflict")),
+    ("transport", ("crash", "derailment", "collision", "pileup", "aviation", "train")),
+    ("storm", ("storm", "thunderstorm", "blizzard", "snow", "wind", "hail")),
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def infer_hazard_type(*texts: str | None) -> str:
+    """Classify a hazard from free text using the keyword taxonomy."""
+
+    haystack = " ".join(t for t in texts if t).lower()
+    if not haystack:
+        return "other"
+    for hazard, keywords in _HAZARD_KEYWORDS:
+        if any(keyword in haystack for keyword in keywords):
+            return hazard
+    return "other"
+
+
+@dataclass
+class EmergencyEvent:
+    """Platform-wide emergency event. Construct via ``from_normalized`` from the
+    ingest pipeline, or ``from_dict``/``from_json`` from a transport."""
+
+    title: str
+    schema_version: str = SCHEMA_VERSION
+    event_id: str = field(default_factory=new_ulid)
+    origin_node_id: Optional[str] = None
+    hazard_type: str = "other"
+    severity: str = "low"
+    confidence: float = 0.0
+    impact_score: int = 1
+    timestamp_utc: str = field(default_factory=_now_iso)
+    event_timestamp_utc: Optional[str] = None
+    location: dict[str, Any] = field(default_factory=dict)
+    summary: str = ""
+    predictive_outcome: str = ""
+    url: Optional[str] = None
+    sources: list[str] = field(default_factory=list)
+    trust: str = trust_tiers.DEFAULT_TRUST
+    # Mesh propagation controls (issues #33/#34).
+    ttl_hops: int = 4
+    seen_nodes: list[str] = field(default_factory=list)
+    # Recommended/dispatched response actions (routing + automation).
+    actions: list[dict[str, Any]] = field(default_factory=list)
+    # Optional Ed25519 signature, populated in Phase 4.
+    signature: Optional[str] = None
+
+    # ----- serialization -------------------------------------------------
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True, ensure_ascii=False)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "EmergencyEvent":
+        known = {f for f in cls.__dataclass_fields__}  # type: ignore[attr-defined]
+        filtered = {k: v for k, v in data.items() if k in known}
+        if "title" not in filtered:
+            filtered["title"] = data.get("title") or "(no title)"
+        return cls(**filtered)
+
+    @classmethod
+    def from_json(cls, raw: str | bytes) -> "EmergencyEvent":
+        return cls.from_dict(json.loads(raw))
+
+    # ----- mesh helpers --------------------------------------------------
+    def mark_seen(self, node_id: str) -> None:
+        """Record that ``node_id`` has handled this event (loop prevention)."""
+
+        if node_id and node_id not in self.seen_nodes:
+            self.seen_nodes.append(node_id)
+
+    def can_forward(self, node_id: str) -> bool:
+        """Whether this node should forward the event onward over the mesh."""
+
+        return self.ttl_hops > 0 and node_id not in self.seen_nodes
+
+    def decremented(self) -> "EmergencyEvent":
+        """Return a copy with one hop consumed, for forwarding to peers."""
+
+        clone = EmergencyEvent.from_dict(self.to_dict())
+        clone.ttl_hops = max(0, self.ttl_hops - 1)
+        return clone
+
+    # ----- validation ----------------------------------------------------
+    def validate(self) -> None:
+        """Raise ``ValueError`` if the event violates the contract invariants.
+
+        Uses ``jsonschema`` against the bundled schema when available, and always
+        applies the cheap structural checks so validation works on dependency-free
+        edge nodes too.
+        """
+
+        if not self.title:
+            raise ValueError("title is required")
+        if self.hazard_type not in HAZARD_TYPES:
+            raise ValueError(f"invalid hazard_type: {self.hazard_type!r}")
+        if self.severity not in SEVERITIES:
+            raise ValueError(f"invalid severity: {self.severity!r}")
+        if not 0.0 <= float(self.confidence) <= 1.0:
+            raise ValueError("confidence must be within [0, 1]")
+        if not 1 <= int(self.impact_score) <= 10:
+            raise ValueError("impact_score must be within [1, 10]")
+        if self.ttl_hops < 0:
+            raise ValueError("ttl_hops must be non-negative")
+        if self.trust not in trust_tiers.TRUST_TIERS:
+            raise ValueError(f"invalid trust tier: {self.trust!r}")
+
+        try:
+            import jsonschema  # type: ignore
+        except Exception:
+            return
+        from .schema import load_schema
+
+        jsonschema.validate(self.to_dict(), load_schema())
+
+    # ----- adapter from the existing pipeline ----------------------------
+    @classmethod
+    def from_normalized(
+        cls,
+        *,
+        normalized: Mapping[str, Any],
+        title: str,
+        snippet: str = "",
+        impact_score: Any = 1,
+        predictive_outcome: str = "",
+        url: Optional[str] = None,
+        source: Optional[str] = None,
+        source_kind: Optional[str] = None,
+        merged_sources: Any = (),
+        origin_node_id: Optional[str] = None,
+        hazard_type: Optional[str] = None,
+        trust: Optional[str] = None,
+    ) -> "EmergencyEvent":
+        """Build an ``EmergencyEvent`` from ``normalize_event_payload`` output.
+
+        ``normalized`` is the dict returned by
+        ``utils.event_normalization.normalize_event_payload`` (severity,
+        confidence, timestamp_utc, location). All v1.0 fields are preserved; the
+        new platform fields are derived or defaulted.
+        """
+
+        location = dict(normalized.get("location") or {})
+        # Enrich location with a geohash for geo-routing/dedup when coords exist.
+        if "geohash" not in location:
+            geo = encode_optional(location.get("latitude"), location.get("longitude"))
+            if geo:
+                location["geohash"] = geo
+
+        sources: list[str] = []
+        for candidate in (source, *(merged_sources or ())):
+            value = str(candidate or "").strip()
+            if value and value not in sources:
+                sources.append(value)
+
+        resolved_trust = trust or trust_tiers.for_source_kind(source_kind)
+        resolved_hazard = hazard_type or infer_hazard_type(title, snippet)
+
+        return cls(
+            title=title or "(no title)",
+            origin_node_id=origin_node_id,
+            hazard_type=resolved_hazard,
+            severity=str(normalized.get("severity", "low")),
+            confidence=float(normalized.get("confidence", 0.0) or 0.0),
+            impact_score=max(1, min(10, int(impact_score or 1))),
+            event_timestamp_utc=normalized.get("timestamp_utc"),
+            location=location,
+            summary=snippet or "",
+            predictive_outcome=predictive_outcome or "",
+            url=url,
+            sources=sources or ["Unknown"],
+            trust=resolved_trust,
+        )

--- a/contracts/geohash.py
+++ b/contracts/geohash.py
@@ -1,0 +1,63 @@
+"""Minimal, dependency-free geohash encoder.
+
+Geohashes turn a lat/lon into a short string where a shared prefix implies
+spatial proximity. The platform uses them for cheap geo-routing and cross-node
+spatial dedup (events about the same area share a geohash prefix) without
+pulling in a geospatial library on low-power field nodes.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+_BASE32 = "0123456789bcdefghjkmnpqrstuvwxyz"
+
+
+def encode(latitude: float, longitude: float, precision: int = 7) -> str:
+    """Encode a coordinate to a geohash of the given precision (default 7 ~= 153m)."""
+
+    lat_range = [-90.0, 90.0]
+    lon_range = [-180.0, 180.0]
+    geohash: list[str] = []
+    bits = [16, 8, 4, 2, 1]
+    bit = 0
+    ch = 0
+    even = True
+
+    while len(geohash) < precision:
+        if even:
+            mid = (lon_range[0] + lon_range[1]) / 2
+            if longitude > mid:
+                ch |= bits[bit]
+                lon_range[0] = mid
+            else:
+                lon_range[1] = mid
+        else:
+            mid = (lat_range[0] + lat_range[1]) / 2
+            if latitude > mid:
+                ch |= bits[bit]
+                lat_range[0] = mid
+            else:
+                lat_range[1] = mid
+        even = not even
+        if bit < 4:
+            bit += 1
+        else:
+            geohash.append(_BASE32[ch])
+            bit = 0
+            ch = 0
+
+    return "".join(geohash)
+
+
+def encode_optional(
+    latitude: Optional[float], longitude: Optional[float], precision: int = 7
+) -> Optional[str]:
+    """Encode only when both coordinates are present; otherwise return ``None``."""
+
+    if latitude is None or longitude is None:
+        return None
+    try:
+        return encode(float(latitude), float(longitude), precision)
+    except (TypeError, ValueError):
+        return None

--- a/contracts/ids.py
+++ b/contracts/ids.py
@@ -1,0 +1,38 @@
+"""Dependency-free ULID generation for cross-node identifiers.
+
+ULIDs are 26-character Crockford base32 strings whose leading 48 bits encode a
+millisecond timestamp, so they sort lexicographically by creation time. That
+time-ordering is what lets the store-and-forward queue and cross-node dedup
+(``event_id``) work without a central clock or coordinator.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+# Crockford base32 alphabet (excludes I, L, O, U to avoid transcription errors).
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+
+def _encode_base32(value: int, length: int) -> str:
+    chars = []
+    for _ in range(length):
+        value, rem = divmod(value, 32)
+        chars.append(_CROCKFORD[rem])
+    return "".join(reversed(chars))
+
+
+def new_ulid(timestamp_ms: int | None = None) -> str:
+    """Return a new 26-character ULID.
+
+    ``timestamp_ms`` may be supplied for deterministic tests; otherwise the
+    current wall-clock time is used. Randomness comes from ``os.urandom`` so the
+    result is unguessable across nodes.
+    """
+
+    if timestamp_ms is None:
+        timestamp_ms = int(time.time() * 1000)
+    timestamp_ms &= (1 << 48) - 1
+    randomness = int.from_bytes(os.urandom(10), "big")  # 80 bits
+    return _encode_base32(timestamp_ms, 10) + _encode_base32(randomness, 16)

--- a/contracts/schema.py
+++ b/contracts/schema.py
@@ -1,0 +1,17 @@
+"""Loader for the bundled EmergencyEvent JSON Schema."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+SCHEMA_PATH = Path(__file__).with_name("emergency_event.schema.json")
+
+
+@lru_cache(maxsize=1)
+def load_schema() -> dict[str, Any]:
+    """Return the parsed EmergencyEvent JSON Schema (cached)."""
+
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))

--- a/contracts/trust.py
+++ b/contracts/trust.py
@@ -1,0 +1,56 @@
+"""Provenance trust tiers for the EmergencyEvent contract.
+
+Trust is the trust boundary the AI/RAG pipeline (issue #70) and the routing
+engine both consult: higher-trust events may be acted on automatically and are
+preferred when channels are contended, while lower-trust content (open web
+search, unauthenticated mesh) must be treated as untrusted input and never be
+allowed to inject instructions into LLM prompts.
+
+The tiers are ordered; ``rank()`` gives a comparable integer (higher = more
+trusted) so callers can threshold or sort without hard-coding the strings.
+"""
+
+from __future__ import annotations
+
+# Ordered from least to most trusted.
+TRUST_TIERS: tuple[str, ...] = (
+    "untrusted",          # unsolicited / unauthenticated mesh or user-pasted content
+    "open_search",        # open web search results (DuckDuckGo, CSE, Bing)
+    "known_feed",         # curated RSS / agency feeds
+    "authenticated_api",  # keyed API (NewsAPI) or authenticated MQTT peer
+    "signed_node",        # cryptographically signed event from a known node (Phase 4)
+)
+
+# Map each existing source_kind to its default trust tier. New transports register
+# their own tier explicitly when they emit events.
+SOURCE_KIND_TRUST: dict[str, str] = {
+    "rss": "known_feed",
+    "emergency_search": "known_feed",
+    "news_api": "authenticated_api",
+    "google_cse": "open_search",
+    "bing_search": "open_search",
+    "duckduckgo": "open_search",
+}
+
+DEFAULT_TRUST = "open_search"
+
+
+def rank(tier: str | None) -> int:
+    """Return a comparable rank for a trust tier (higher = more trusted)."""
+
+    try:
+        return TRUST_TIERS.index((tier or "").strip().lower())
+    except ValueError:
+        return TRUST_TIERS.index(DEFAULT_TRUST)
+
+
+def for_source_kind(source_kind: str | None) -> str:
+    """Best-effort trust tier for a legacy ``source_kind`` string."""
+
+    return SOURCE_KIND_TRUST.get((source_kind or "").strip().lower(), DEFAULT_TRUST)
+
+
+def is_trusted_for_automation(tier: str | None, *, minimum: str = "known_feed") -> bool:
+    """Whether an event at ``tier`` is trusted enough to drive automated actions."""
+
+    return rank(tier) >= rank(minimum)

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ Welcome to the VigilantCore documentation.
 | [Features](features.md) | Complete feature documentation |
 | [Source Discovery & Regional Coverage](source-discovery.md) | How outage/emergency/cross-region source selection works |
 | [Examples](examples.md) | Real-world usage examples |
+| [Platform Architecture](architecture.md) | Plugin kernel, event bus, and mesh node model |
+| [EmergencyEvent Schema](emergency-event-schema.md) | The canonical cross-node event contract (v2.0) |
 
 ## Quick Links
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,131 @@
+# VigilantCore Platform Architecture
+
+VigilantCore is evolving from a single-node event monitor into the coordinating
+**centerpiece for emergency action** — a system that monitors adverse events,
+reacts with or without internet and grid power, communicates over whatever links
+are available (LoRa/Meshtastic mesh, satellite, BLE, MQTT/LAN), informs other
+systems and responders, and uses local AI to fuse and prioritize.
+
+This document describes the **plugin kernel** that makes that possible. It was
+introduced in Phase 1 (architecture & contracts) and is the foundation every
+later capability builds on. It is fully backward compatible: with no plugins
+configured, VigilantCore behaves exactly as before.
+
+## The big picture
+
+```
+                         vigilant-core (Python hub)
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  INGEST            FUSION / AI            ROUTING            EGRESS     │
+  │  source plugins →  normalize → dedup  →   policy engine  →  transport  │
+  │  (RSS, APIs,       → impact (Ollama)  →   (urgency, geo,    + device   │
+  │   LoRa-in,           → AI fusion         channel, power)     plugins   │
+  │   sensors,         EmergencyEvent      MultiChannelRouter   (LoRa-out, │
+  │   MQTT-in)         (canonical, v2.0)   (Phase 2)            BLE, sat,   │
+  │                          │                                  MQTT, UI,  │
+  │                    SQLite store +                           siren)     │
+  │                    store-and-forward (mesh)                            │
+  └────────────┬─────────────────────────────────────────────┬───────────┘
+               │ shared EmergencyEvent contract (JSON)        │
+        ┌──────┴───────┐                              ┌────────┴────────┐
+        │ edge/ daemons │ (Rust/Go, low-power)        │ sibling apps    │
+        │ lora, mesh,   │  bridged via MQTT/stdio      │ via MQTT bus    │
+        │ satellite,    │                              │                 │
+        │ ble, power    │                              │                 │
+        └───────────────┘                              └─────────────────┘
+```
+
+## Components
+
+### The contract — `contracts/`
+
+`contracts.EmergencyEvent` is the single shape every component agrees on. It is a
+strict superset of the v1.0 normalized alert produced by
+`utils.event_normalization.normalize_event_payload`, so existing alerts upgrade
+losslessly (`EmergencyEvent.from_normalized`). New platform fields — a stable
+`event_id` (ULID), `origin_node_id`, `hazard_type`, `trust` tier, mesh
+`ttl_hops`/`seen_nodes`, and recommended `actions` — enable cross-node
+propagation, routing, and trust decisions. See
+[emergency-event-schema.md](emergency-event-schema.md).
+
+The contract is the boundary that lets the Rust/Go edge daemons (Phase 2) and
+sibling apps interoperate without sharing Python code: they exchange
+schema-valid JSON over MQTT/stdio.
+
+### The plugin kernel — `plugins/`
+
+Every capability is a plugin of one of four kinds (`plugins/base.py`):
+
+| Kind | Base class | Contract method | Examples |
+|------|-----------|-----------------|----------|
+| Source | `SourcePlugin` | `async poll(ctx) -> [EmergencyEvent]` | RSS, sensors, LoRa-in, MQTT-in |
+| Transport | `TransportPlugin` | `send(event)` (+ inbound to bus) | MQTT, LoRa/Meshtastic, BLE, satellite |
+| Device | `DevicePlugin` | `render(event)` | siren, display, GPIO relay, notification |
+| Sink | `SinkPlugin` | `handle(event)` | webhook, shell action, digest, export |
+
+Plugins communicate through an in-process **`EventBus`** (publish/subscribe),
+which replaces the engine's single `on_new_alert` callback. Topics:
+
+- `event.new` — every newly stored alert (transports + sinks subscribe).
+- `event.high` — high/critical only (devices like sirens default to this).
+- `event.ingest` — inbound events from transports re-entering the pipeline.
+
+Every plugin reports health in the same shape as the v0.8.0 source-health
+telemetry (`PluginHealth`: attempts, successes, errors, latency), so the
+dashboard can show all of them uniformly.
+
+### Lifecycle — `plugins/loader.py` + `plugins/registry.py`
+
+Plugins are declared in config (`AppConfig.plugins`) and loaded by `build_registry`:
+
+```json
+{
+  "plugins": [
+    {"type": "rss_source", "name": "county-rss", "enabled": true,
+     "options": {"feeds": ["https://example.gov/alerts.rss"]}},
+    {"type": "mqtt_transport", "name": "bus", "enabled": true,
+     "options": {"host": "127.0.0.1", "base_topic": "intel/events"}},
+    {"type": "notify_device", "name": "siren", "enabled": true, "options": {}}
+  ]
+}
+```
+
+`type` resolves to a built-in plugin or a `"module:ClassName"` path for
+out-of-tree plugins. The registry starts each plugin, wires egress plugins to bus
+topics, polls sources each cycle, and fans stored events out to egress.
+
+### Mesh node identity + store-and-forward — `mesh/`
+
+- `mesh/node.py` — a persistent `node_id` (ULID), label, and role
+  (`hub`/`edge`/`relay`) under the platform data dir, so events can record their
+  origin and travel path.
+- `mesh/forwarding.py` — a SQLite-backed store-and-forward queue implementing
+  **gossip / flood-with-suppression**: duplicate `event_id`s and looped events
+  (this node already in `seen_nodes`) are suppressed; otherwise the node stamps
+  itself and enqueues a hop-decremented copy. `ttl_hops` bounds flooding (mesh
+  storm protection). The queue survives power loss because it is persisted.
+
+Phase 1 ships the model + reference algorithm; Phase 2's radios drive it.
+
+## How the engine uses it
+
+`engine/monitor.py` (`MonitorEngine`) gains a platform layer that degrades
+gracefully — if an optional plugin/transport dependency is missing, monitoring
+still runs:
+
+1. **Ingest** — `gather_items()` additionally pulls `registry.poll_sources()`
+   and any buffered inbound transport events, feeding them through the same
+   dedup/location pipeline as native fetchers.
+2. **Egress** — when `process_items()` stores a new alert, it builds an
+   `EmergencyEvent`, offers it to the store-and-forward queue, and publishes it
+   to the bus, where transports/devices/sinks react.
+
+## Roadmap
+
+Phase 1 (this) ships contracts, the kernel, node/forwarding model, and three
+reference plugins (RSS source, MQTT transport, notify device). Later phases —
+multi-channel routing, LoRa/BLE/satellite transports + Rust/Go edge daemons,
+encrypted offline storage, LLM gateway, AI fusion, prompt-injection hardening,
+event signing — each land as plugins or additive modules against this contract.
+See the project plan and the issue tracker (#12/#19/#40, #25–#29, #33/#34, #42,
+#35, #36, #37, #39, #57–#60, #67, #70).

--- a/docs/emergency-event-schema.md
+++ b/docs/emergency-event-schema.md
@@ -1,0 +1,103 @@
+# EmergencyEvent Schema (v2.0)
+
+`EmergencyEvent` is the canonical, versioned contract every platform component
+exchanges — the ingest pipeline, the dashboard, the MQTT bus, sibling apps, and
+the Rust/Go edge daemons. It is defined in `contracts/` with:
+
+- `contracts/emergency_event.schema.json` — the JSON Schema (draft 2020-12).
+- `contracts/event.py` — the `EmergencyEvent` dataclass, validator, and the
+  `from_normalized()` adapter.
+
+It is a **strict superset of the v1.0 normalized alert** (see
+[event-normalization.md](event-normalization.md)), so existing alerts upgrade
+without data loss while new fields enable cross-node propagation, routing, and
+trust. This schema is the basis for ShelfCast-compatible MQTT output (issue #60).
+
+## Fields
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `schema_version` | string (`"2.0"`) | yes | Contract version. |
+| `event_id` | string (ULID) | yes | Stable id for cross-node dedup. |
+| `origin_node_id` | string \| null | no | Node that first observed/produced it. |
+| `title` | string | yes | Headline. |
+| `hazard_type` | enum | yes | `storm`, `hurricane`, `tornado`, `fire`, `flood`, `earthquake`, `outage`, `hazmat`, `conflict`, `transport`, `medical`, `other`. |
+| `severity` | enum | yes | `low`, `medium`, `high`, `critical`. |
+| `confidence` | number 0–1 | yes | Source/relevance-derived confidence. |
+| `impact_score` | integer 1–10 | yes | Impact magnitude. |
+| `timestamp_utc` | string (ISO-8601) | yes | When the record was observed/created. |
+| `event_timestamp_utc` | string \| null | no | When the hazard occurred. |
+| `location` | object | no | `{name, zip_code, latitude, longitude, radius_km, geohash}`. |
+| `summary` | string | no | Short description. |
+| `predictive_outcome` | string | no | AI/heuristic prediction of what happens next. |
+| `url` | string \| null | no | Canonical source URL. |
+| `sources` | string[] | no | Provenance (merged source names). |
+| `trust` | enum | no | `untrusted` < `open_search` < `known_feed` < `authenticated_api` < `signed_node`. |
+| `ttl_hops` | integer ≥ 0 | no | Remaining mesh hops; decremented per forward. |
+| `seen_nodes` | string[] | no | Nodes that handled it (loop prevention). |
+| `actions` | object[] | no | Recommended/dispatched actions (`{kind, detail, status}`). |
+| `signature` | string \| null | no | Optional Ed25519 signature (Phase 4). |
+
+## Trust tiers
+
+`trust` is the boundary the AI/RAG pipeline (issue #70) and the routing engine
+consult. Higher-trust events may be acted on automatically and are preferred when
+channels are contended; lower-trust content (open web search, unauthenticated
+mesh) is treated as untrusted input and must never inject instructions into LLM
+prompts. `contracts.trust` maps legacy `source_kind`s to tiers and exposes
+`rank()` / `is_trusted_for_automation()`.
+
+## Example
+
+```json
+{
+  "schema_version": "2.0",
+  "event_id": "01J9Z3R8K2QF7M4V0WXYABCDEF",
+  "origin_node_id": "01J9Z000NODE000000000HUB00",
+  "title": "Tornado Warning issued for Mercer County",
+  "hazard_type": "tornado",
+  "severity": "high",
+  "confidence": 0.86,
+  "impact_score": 8,
+  "timestamp_utc": "2026-06-19T18:00:00Z",
+  "event_timestamp_utc": "2026-06-19T17:58:00Z",
+  "location": {"name": "Mercer County, NJ", "zip_code": "08540",
+               "latitude": 40.34, "longitude": -74.65, "geohash": "dr4vmr9"},
+  "summary": "Take shelter now; storm capable of producing a tornado.",
+  "predictive_outcome": "Damaging winds and possible touchdown within 30 minutes.",
+  "url": "https://example.gov/alerts/123",
+  "sources": ["NWS"],
+  "trust": "known_feed",
+  "ttl_hops": 4,
+  "seen_nodes": ["01J9Z000NODE000000000HUB00"],
+  "actions": [],
+  "signature": null
+}
+```
+
+## Usage
+
+```python
+from contracts import EmergencyEvent
+
+# Build from the existing normalization output (ingest path):
+event = EmergencyEvent.from_normalized(normalized=normalized_payload,
+                                       title=title, snippet=snippet,
+                                       impact_score=8, source="NWS",
+                                       source_kind="rss")
+event.validate()          # raises on contract violation (uses jsonschema if present)
+payload = event.to_json()  # for MQTT/transports
+
+# Parse on the receiving side (transport / edge daemon):
+received = EmergencyEvent.from_json(payload)
+```
+
+## MQTT topics
+
+The MQTT transport (`plugins/builtin/mqtt_transport.py`) publishes schema-valid
+events to:
+
+- `intel/events/normalized` — every event (issue #57).
+- `intel/events/high_priority` — `high`/`critical` events (issue #58).
+
+Base topic is configurable via the plugin's `base_topic` option.

--- a/engine/monitor.py
+++ b/engine/monitor.py
@@ -19,7 +19,11 @@ import feedparser
 import httpx
 import pgeocode
 
-from .parser import ImpactParser
+from .parser import ImpactParser, ParsedImpact
+from contracts import EmergencyEvent
+from mesh.forwarding import ForwardingQueue
+from mesh.node import load_or_create_node
+from plugins import build_registry
 from utils import database
 from utils.config import AppConfig, config_dir
 from utils.event_deduplication import deduplicate_events
@@ -100,6 +104,43 @@ class MonitorEngine:
             prefer_light_model=config.prefer_light_model,
         )
         self.model_name = self._parser.current_model()
+
+        # Platform layer: node identity, plugin kernel, store-and-forward queue.
+        # Wrapped so a field node still monitors even if an optional plugin or
+        # transport dependency is unavailable.
+        self.node = None
+        self.node_id: Optional[str] = None
+        self.registry = None
+        self.forwarding: Optional[ForwardingQueue] = None
+        self._inbound_lock = threading.Lock()
+        self._inbound_events: List[EmergencyEvent] = []
+        try:
+            self.node = load_or_create_node(
+                label=config.node_label, role=config.node_role
+            )
+            self.node_id = self.node.node_id
+            self.registry = build_registry(config, node_id=self.node_id)
+            self.registry.subscribe_ingest(self._buffer_inbound_event)
+            self.forwarding = ForwardingQueue(self.node_id)
+        except Exception:
+            logger.exception("Platform layer init failed; continuing in standalone mode")
+
+    def _buffer_inbound_event(self, event: EmergencyEvent) -> None:
+        """Bus handler for events received from transports (TOPIC_INGEST)."""
+
+        with self._inbound_lock:
+            self._inbound_events.append(event)
+
+    def _drain_inbound_events(self) -> List[EmergencyEvent]:
+        with self._inbound_lock:
+            drained = self._inbound_events
+            self._inbound_events = []
+        return drained
+
+    def get_plugin_health(self) -> List[Dict[str, object]]:
+        """Plugin health snapshots for the dashboard (empty when no plugins)."""
+
+        return self.registry.health() if self.registry else []
 
     def _is_source_enabled(self, source_key: str) -> bool:
         if source_key == "rss":
@@ -967,6 +1008,9 @@ class MonitorEngine:
             combined = []
             for group in results:
                 combined.extend(group)
+        plugin_items = await self._gather_plugin_items()
+        if plugin_items:
+            combined.extend(plugin_items)
         logger.info("Fetched %d raw items before filtering", len(combined))
         seen = set()
         filtered_items = []
@@ -1030,6 +1074,66 @@ class MonitorEngine:
             "https://news.google.com/rss/search"
             f"?q={query}&hl=en-US&gl=US&ceid=US:en"
         )
+
+    async def _gather_plugin_items(self) -> List[AlertItem]:
+        """Pull events from source plugins and buffered inbound transports.
+
+        These re-enter the normal dedup/store pipeline as ``AlertItem``s, so they
+        get the same location filtering and dedup as native fetchers.
+        """
+
+        if self.registry is None:
+            return []
+        events: List[EmergencyEvent] = []
+        try:
+            events.extend(await self.registry.poll_sources())
+        except Exception:
+            logger.exception("Source plugin polling failed")
+        events.extend(self._drain_inbound_events())
+        return [self._event_to_alert_item(event) for event in events]
+
+    @staticmethod
+    def _event_to_alert_item(event: EmergencyEvent) -> AlertItem:
+        source = event.sources[0] if event.sources else "plugin"
+        return AlertItem(
+            url=event.url or event.event_id,
+            title=event.title,
+            snippet=event.summary,
+            published_at=event.event_timestamp_utc,
+            source=source,
+            source_kind="plugin",
+        )
+
+    def _publish_platform_event(
+        self,
+        item: AlertItem,
+        parsed: ParsedImpact,
+        normalized: Dict,
+    ) -> None:
+        """Emit a stored alert as an EmergencyEvent to the mesh + egress plugins."""
+
+        if self.registry is None and self.forwarding is None:
+            return
+        try:
+            event = EmergencyEvent.from_normalized(
+                normalized=normalized,
+                title=item.title,
+                snippet=item.snippet,
+                impact_score=parsed.impact_score,
+                predictive_outcome=parsed.predictive_outcome,
+                url=item.url,
+                source=item.source,
+                source_kind=item.source_kind,
+                merged_sources=item.merged_sources,
+                origin_node_id=self.node_id,
+            )
+            # Stamp this node + enqueue a hop for forwarding (store-and-forward).
+            if self.forwarding is not None:
+                self.forwarding.offer(event)
+            if self.registry is not None:
+                self.registry.publish(event)
+        except Exception:
+            logger.exception("Failed to publish platform event for %s", item.url)
 
     async def process_items(self, items: Iterable[AlertItem]) -> int:
         new_count = 0
@@ -1098,6 +1202,7 @@ class MonitorEngine:
                             "created_at": datetime.utcnow().isoformat(),
                         }
                     )
+                self._publish_platform_event(item, parsed, normalized)
         logger.info("Processed %d items, inserted %d", total, new_count)
         return new_count
 

--- a/mesh/__init__.py
+++ b/mesh/__init__.py
@@ -1,0 +1,14 @@
+"""Mesh node identity and store-and-forward primitives for VigilantCore."""
+
+from __future__ import annotations
+
+from .forwarding import ForwardingQueue, OfferResult
+from .node import Node, load_or_create_node, node_path
+
+__all__ = [
+    "Node",
+    "load_or_create_node",
+    "node_path",
+    "ForwardingQueue",
+    "OfferResult",
+]

--- a/mesh/forwarding.py
+++ b/mesh/forwarding.py
@@ -1,0 +1,166 @@
+"""Store-and-forward queue + cross-node dedup for mesh propagation.
+
+This is the data model and reference algorithm behind distributed rapid alert
+propagation (#33) and mesh storm protection (#34); Phase 2's radios drive it.
+
+The model is gossip / flood-with-suppression:
+
+* Each event carries a stable ``event_id``, a ``ttl_hops`` budget, and the list
+  of ``seen_nodes`` it has passed through.
+* When a node *offers* an event (locally produced or received from a peer), the
+  queue suppresses it if this node already appears in ``seen_nodes`` (it looped)
+  or if the ``event_id`` was seen before (a duplicate arriving by another path).
+* Otherwise the node stamps itself into ``seen_nodes`` and, if ``ttl_hops`` is
+  left, enqueues a hop-decremented copy for transports to forward. Decrementing
+  TTL bounds flooding so a storm of duplicates cannot amplify across the mesh.
+
+Everything is persisted in SQLite (the platform DB) so an edge node that loses
+power resumes with its dedup memory and pending forwards intact.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, List
+
+from contracts import EmergencyEvent
+from utils import database
+
+
+@dataclass
+class OfferResult:
+    status: str        # "new" | "duplicate" | "looped"
+    will_forward: bool  # whether a hop-decremented copy was enqueued
+
+    @property
+    def accepted(self) -> bool:
+        return self.status == "new"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+class ForwardingQueue:
+    """SQLite-backed store-and-forward queue with cross-node dedup.
+
+    ``connect`` defaults to the platform DB connection but can be injected with a
+    factory pointing at a temp database for tests.
+    """
+
+    def __init__(
+        self,
+        node_id: str,
+        connect: Callable[[], sqlite3.Connection] = database.connect,
+    ) -> None:
+        self.node_id = node_id
+        self._connect = connect
+        self.init_schema()
+
+    def init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mesh_seen_events (
+                    event_id TEXT PRIMARY KEY,
+                    first_seen_utc TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mesh_forward_queue (
+                    event_id TEXT PRIMARY KEY,
+                    payload_json TEXT NOT NULL,
+                    ttl_hops INTEGER NOT NULL,
+                    enqueued_utc TEXT NOT NULL,
+                    forwarded INTEGER NOT NULL DEFAULT 0,
+                    attempts INTEGER NOT NULL DEFAULT 0
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mesh_queue_forwarded "
+                "ON mesh_forward_queue(forwarded)"
+            )
+
+    # ----- dedup memory --------------------------------------------------
+    def has_seen(self, event_id: str) -> bool:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT 1 FROM mesh_seen_events WHERE event_id = ? LIMIT 1", (event_id,)
+            )
+            return cur.fetchone() is not None
+
+    def _record_seen(self, conn: sqlite3.Connection, event_id: str) -> None:
+        conn.execute(
+            "INSERT OR IGNORE INTO mesh_seen_events (event_id, first_seen_utc) VALUES (?, ?)",
+            (event_id, _now_iso()),
+        )
+
+    # ----- core gossip logic --------------------------------------------
+    def offer(self, event: EmergencyEvent) -> OfferResult:
+        """Consider an event for forwarding; suppress loops and duplicates."""
+
+        if self.node_id in event.seen_nodes:
+            return OfferResult("looped", False)
+        if self.has_seen(event.event_id):
+            return OfferResult("duplicate", False)
+
+        event.mark_seen(self.node_id)
+        will_forward = event.ttl_hops > 0
+        with self._connect() as conn:
+            self._record_seen(conn, event.event_id)
+            if will_forward:
+                forward_copy = event.decremented()
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO mesh_forward_queue
+                        (event_id, payload_json, ttl_hops, enqueued_utc)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (
+                        forward_copy.event_id,
+                        forward_copy.to_json(),
+                        forward_copy.ttl_hops,
+                        _now_iso(),
+                    ),
+                )
+        return OfferResult("new", will_forward)
+
+    # ----- queue draining (transports call these) ------------------------
+    def pending(self, limit: int = 100) -> List[EmergencyEvent]:
+        """Return enqueued, not-yet-forwarded events (oldest first)."""
+
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT payload_json FROM mesh_forward_queue "
+                "WHERE forwarded = 0 ORDER BY enqueued_utc ASC LIMIT ?",
+                (limit,),
+            )
+            rows = cur.fetchall()
+        events: List[EmergencyEvent] = []
+        for row in rows:
+            try:
+                events.append(EmergencyEvent.from_json(row["payload_json"]))
+            except (KeyError, json.JSONDecodeError, TypeError):
+                continue
+        return events
+
+    def mark_forwarded(self, event_id: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE mesh_forward_queue SET forwarded = 1, attempts = attempts + 1 "
+                "WHERE event_id = ?",
+                (event_id,),
+            )
+
+    def pending_count(self) -> int:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT COUNT(*) AS c FROM mesh_forward_queue WHERE forwarded = 0"
+            )
+            return int(cur.fetchone()["c"])

--- a/mesh/node.py
+++ b/mesh/node.py
@@ -1,0 +1,73 @@
+"""Persistent node identity for the VigilantCore mesh.
+
+Every install has a stable ``node_id`` so events can record their origin and the
+path they have travelled (``origin_node_id``, ``seen_nodes``). Identity is stored
+once under the platform data dir and reused across restarts; without it, mesh
+dedup and loop-prevention have nothing to key on.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from contracts import new_ulid
+from utils.config import data_dir
+
+NODE_FILE = "node.json"
+VALID_ROLES = ("hub", "edge", "relay")
+
+
+@dataclass
+class Node:
+    node_id: str
+    label: str
+    role: str
+    created_at: str
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+def node_path(base: Optional[Path] = None) -> Path:
+    base = base or data_dir()
+    base.mkdir(parents=True, exist_ok=True)
+    return base / NODE_FILE
+
+
+def load_or_create_node(
+    *,
+    base: Optional[Path] = None,
+    label: Optional[str] = None,
+    role: str = "hub",
+) -> Node:
+    """Load this node's identity, creating and persisting it on first run."""
+
+    path = node_path(base)
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return Node(
+                node_id=str(data["node_id"]),
+                label=str(data.get("label") or data["node_id"]),
+                role=str(data.get("role") or "hub"),
+                created_at=str(data.get("created_at") or _now_iso()),
+            )
+        except Exception:
+            # Corrupt identity file: fall through and recreate.
+            pass
+    node = Node(
+        node_id=new_ulid(),
+        label=label or "vigilant-node",
+        role=role if role in VALID_ROLES else "hub",
+        created_at=_now_iso(),
+    )
+    path.write_text(json.dumps(node.as_dict(), indent=2), encoding="utf-8")
+    return node
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,41 @@
+"""VigilantCore plugin kernel.
+
+Public surface: the plugin base classes and the :class:`EventBus`/registry that
+turn ingest, transport, device, and automation capabilities into composable
+plugins speaking the :class:`~contracts.EmergencyEvent` contract.
+"""
+
+from __future__ import annotations
+
+from .base import (
+    DevicePlugin,
+    EventBus,
+    Plugin,
+    PluginContext,
+    PluginHealth,
+    SinkPlugin,
+    SourcePlugin,
+    TransportPlugin,
+    TOPIC_HIGH,
+    TOPIC_INGEST,
+    TOPIC_NEW,
+)
+from .loader import BUILTIN_PLUGINS, build_registry
+from .registry import PluginRegistry
+
+__all__ = [
+    "Plugin",
+    "SourcePlugin",
+    "TransportPlugin",
+    "DevicePlugin",
+    "SinkPlugin",
+    "PluginContext",
+    "PluginHealth",
+    "EventBus",
+    "PluginRegistry",
+    "build_registry",
+    "BUILTIN_PLUGINS",
+    "TOPIC_NEW",
+    "TOPIC_HIGH",
+    "TOPIC_INGEST",
+]

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -1,0 +1,205 @@
+"""Plugin contracts and the in-process event bus for VigilantCore.
+
+The kernel turns every capability — fetching sources, talking to other nodes,
+driving local devices, running automations — into a plugin of one of four kinds
+that all speak the :class:`~contracts.EmergencyEvent` contract and report health
+in a single, dashboard-friendly shape (the same telemetry introduced for source
+health in v0.8.0). The :class:`EventBus` replaces the engine's single
+``on_new_alert`` callback with publish/subscribe so any number of plugins can
+react to an event without editing the engine.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+from contracts import EmergencyEvent
+
+logger = logging.getLogger(__name__)
+
+# Bus topics. Egress plugins subscribe to what they care about; the engine
+# publishes every stored alert to NEW and additionally to HIGH when severe.
+TOPIC_NEW = "event.new"          # every newly stored alert
+TOPIC_HIGH = "event.high"        # severity high/critical only
+TOPIC_INGEST = "event.ingest"    # inbound events from transports/sources -> pipeline
+
+# Plugin kinds.
+KIND_SOURCE = "source"
+KIND_TRANSPORT = "transport"
+KIND_DEVICE = "device"
+KIND_SINK = "sink"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+@dataclass
+class PluginHealth:
+    """Uniform health telemetry for every plugin (mirrors source-health v0.8.0)."""
+
+    name: str
+    kind: str
+    enabled: bool = True
+    last_attempt_utc: Optional[str] = None
+    last_success_utc: Optional[str] = None
+    last_error_utc: Optional[str] = None
+    last_error: Optional[str] = None
+    attempt_count: int = 0
+    success_count: int = 0
+    error_count: int = 0
+    last_latency_ms: Optional[float] = None
+    last_item_count: int = 0
+
+    def record_success(self, *, latency_ms: float = 0.0, item_count: int = 0) -> None:
+        now = _now_iso()
+        self.last_attempt_utc = now
+        self.last_success_utc = now
+        self.attempt_count += 1
+        self.success_count += 1
+        self.last_latency_ms = round(max(0.0, float(latency_ms)), 2)
+        self.last_item_count = max(0, int(item_count))
+        self.last_error = None
+
+    def record_error(self, message: str, *, latency_ms: float = 0.0) -> None:
+        now = _now_iso()
+        self.last_attempt_utc = now
+        self.last_error_utc = now
+        self.attempt_count += 1
+        self.error_count += 1
+        self.last_latency_ms = round(max(0.0, float(latency_ms)), 2)
+        self.last_error = (message or "error")[:240].strip() or "error"
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "enabled": self.enabled,
+            "last_attempt_utc": self.last_attempt_utc,
+            "last_success_utc": self.last_success_utc,
+            "last_error_utc": self.last_error_utc,
+            "last_error": self.last_error,
+            "attempt_count": self.attempt_count,
+            "success_count": self.success_count,
+            "error_count": self.error_count,
+            "last_latency_ms": self.last_latency_ms,
+            "last_item_count": self.last_item_count,
+        }
+
+
+Subscriber = Callable[[EmergencyEvent], None]
+
+
+class EventBus:
+    """Thread-safe, synchronous, in-process publish/subscribe for events.
+
+    Handlers are isolated: one failing subscriber never blocks the others or the
+    publisher. This is deliberately simple — the same semantics work on a Pi as
+    in tests, and durable cross-node delivery is the transports' job, not the bus'.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._subs: Dict[str, List[Subscriber]] = {}
+
+    def subscribe(self, topic: str, handler: Subscriber) -> None:
+        with self._lock:
+            self._subs.setdefault(topic, []).append(handler)
+
+    def unsubscribe(self, topic: str, handler: Subscriber) -> None:
+        with self._lock:
+            handlers = self._subs.get(topic)
+            if handlers and handler in handlers:
+                handlers.remove(handler)
+
+    def publish(self, topic: str, event: EmergencyEvent) -> int:
+        """Deliver ``event`` to every subscriber of ``topic``. Returns delivery count."""
+
+        with self._lock:
+            handlers = list(self._subs.get(topic, ()))
+        delivered = 0
+        for handler in handlers:
+            try:
+                handler(event)
+                delivered += 1
+            except Exception:  # pragma: no cover - defensive isolation
+                logger.exception("EventBus subscriber on %s failed", topic)
+        return delivered
+
+
+@dataclass
+class PluginContext:
+    """Everything a plugin needs from the host at startup."""
+
+    bus: EventBus
+    config: Any
+    node_id: Optional[str] = None
+    options: Dict[str, Any] = field(default_factory=dict)
+
+
+class Plugin(ABC):
+    """Base class for all plugins."""
+
+    kind: str = "plugin"
+
+    def __init__(self, name: str, options: Optional[Dict[str, Any]] = None) -> None:
+        self.name = name
+        self.options = options or {}
+        self.health = PluginHealth(name=name, kind=self.kind)
+
+    def start(self, ctx: PluginContext) -> None:
+        """Acquire resources and wire bus subscriptions. Override as needed."""
+
+    def stop(self) -> None:
+        """Release resources. Override as needed."""
+
+    def health_snapshot(self) -> Dict[str, Any]:
+        return self.health.as_dict()
+
+
+class SourcePlugin(Plugin):
+    """Produces events. The engine calls :meth:`poll` each cycle and ingests the
+    returned events through the normal dedup/store pipeline."""
+
+    kind = KIND_SOURCE
+
+    @abstractmethod
+    async def poll(self, ctx: PluginContext) -> List[EmergencyEvent]:
+        """Return any new events discovered this cycle (may be empty)."""
+
+
+class TransportPlugin(Plugin):
+    """Bidirectional link to other nodes/devices. Outbound via :meth:`send`
+    (the kernel subscribes it to the bus); inbound by publishing received events
+    to ``TOPIC_INGEST`` so they re-enter the pipeline."""
+
+    kind = KIND_TRANSPORT
+
+    @abstractmethod
+    def send(self, event: EmergencyEvent) -> None:
+        """Transmit an event to peers/devices over this transport."""
+
+
+class DevicePlugin(Plugin):
+    """Local output device (siren, display, GPIO relay, native notification)."""
+
+    kind = KIND_DEVICE
+
+    @abstractmethod
+    def render(self, event: EmergencyEvent) -> None:
+        """Present/actuate the event on the local device."""
+
+
+class SinkPlugin(Plugin):
+    """Side-effecting consumer (webhook, shell action, digest, export)."""
+
+    kind = KIND_SINK
+
+    @abstractmethod
+    def handle(self, event: EmergencyEvent) -> None:
+        """Process the event (fire webhook, append to digest, etc.)."""

--- a/plugins/builtin/__init__.py
+++ b/plugins/builtin/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in reference plugins shipped with VigilantCore."""

--- a/plugins/builtin/mqtt_transport.py
+++ b/plugins/builtin/mqtt_transport.py
@@ -1,0 +1,122 @@
+"""MQTT transport plugin — publishes events to the ShelfCast-compatible bus.
+
+Outbound: every event is published as schema-valid JSON to
+``<base_topic>/normalized``; high/critical events additionally go to
+``<base_topic>/high_priority`` (issues #57/#58/#59, schema #60). Inbound:
+when ``subscribe_inbound`` is set, events received on ``<base_topic>/ingest``
+are republished to the local bus' ``TOPIC_INGEST`` so they re-enter the pipeline.
+
+``paho-mqtt`` is imported lazily and a client can be injected via
+``options['client']`` for tests, so importing this module never requires a broker.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from contracts import EmergencyEvent
+
+from ..base import PluginContext, TransportPlugin, TOPIC_INGEST
+
+logger = logging.getLogger(__name__)
+
+NORMALIZED_SUFFIX = "normalized"
+HIGH_PRIORITY_SUFFIX = "high_priority"
+INGEST_SUFFIX = "ingest"
+_HIGH_SEVERITIES = {"high", "critical"}
+
+
+class MqttTransportPlugin(TransportPlugin):
+    def __init__(self, name: str, options: Optional[dict[str, Any]] = None) -> None:
+        super().__init__(name, options)
+        self._client = self.options.get("client")  # injectable for tests
+        self._ctx: Optional[PluginContext] = None
+        self._base_topic = str(self.options.get("base_topic", "intel/events")).rstrip("/")
+        self._validate = bool(self.options.get("validate", True))
+
+    # ----- lifecycle -----------------------------------------------------
+    def start(self, ctx: PluginContext) -> None:
+        self._ctx = ctx
+        if self._client is None:
+            self._client = self._connect()
+        if self._client is not None and self.options.get("subscribe_inbound"):
+            self._subscribe_inbound()
+
+    def _connect(self):
+        try:
+            import paho.mqtt.client as mqtt  # type: ignore
+        except Exception:
+            logger.warning(
+                "paho-mqtt not installed; MQTT transport %s is inert (install paho-mqtt)",
+                self.name,
+            )
+            return None
+        host = self.options.get("host", "127.0.0.1")
+        port = int(self.options.get("port", 1883))
+        client = mqtt.Client()
+        username = self.options.get("username")
+        if username:
+            client.username_pw_set(username, self.options.get("password"))
+        try:
+            client.connect(host, port, keepalive=int(self.options.get("keepalive", 60)))
+            client.loop_start()
+        except Exception as exc:
+            logger.warning("MQTT transport %s failed to connect: %s", self.name, exc)
+            self.health.record_error(f"connect failed: {exc}")
+            return None
+        return client
+
+    def _subscribe_inbound(self) -> None:
+        topic = f"{self._base_topic}/{INGEST_SUFFIX}"
+
+        def _on_message(_client, _userdata, message) -> None:
+            try:
+                event = EmergencyEvent.from_json(message.payload)
+                if self._ctx is not None:
+                    self._ctx.bus.publish(TOPIC_INGEST, event)
+            except Exception:
+                logger.exception("MQTT transport %s: bad inbound payload", self.name)
+
+        try:
+            self._client.on_message = _on_message
+            self._client.subscribe(topic)
+        except Exception as exc:  # pragma: no cover - broker dependent
+            logger.warning("MQTT transport %s inbound subscribe failed: %s", self.name, exc)
+
+    def stop(self) -> None:
+        client = self._client
+        if client is None:
+            return
+        for closer in ("loop_stop", "disconnect"):
+            try:
+                getattr(client, closer)()
+            except Exception:
+                pass
+
+    # ----- outbound ------------------------------------------------------
+    def send(self, event: EmergencyEvent) -> None:
+        if self._client is None:
+            return
+        if self._validate:
+            event.validate()  # raises on contract violation before we publish
+        payload = event.to_json()
+        self._publish(f"{self._base_topic}/{NORMALIZED_SUFFIX}", payload)
+        if str(event.severity).lower() in _HIGH_SEVERITIES:
+            self._publish(f"{self._base_topic}/{HIGH_PRIORITY_SUFFIX}", payload)
+
+    def _publish(self, topic: str, payload: str) -> None:
+        result = self._client.publish(topic, payload)
+        # paho returns an object with rc; injected fakes may return anything.
+        rc = getattr(result, "rc", 0)
+        if rc not in (0, None):
+            raise RuntimeError(f"MQTT publish to {topic} failed rc={rc}")
+        logger.debug("MQTT %s -> %s (%d bytes)", self.name, topic, len(payload))
+
+    def published_topics_for(self, event: EmergencyEvent) -> list[str]:
+        """Topics ``send`` would target for ``event`` (handy for tests/docs)."""
+
+        topics = [f"{self._base_topic}/{NORMALIZED_SUFFIX}"]
+        if str(event.severity).lower() in _HIGH_SEVERITIES:
+            topics.append(f"{self._base_topic}/{HIGH_PRIORITY_SUFFIX}")
+        return topics

--- a/plugins/builtin/notify_device.py
+++ b/plugins/builtin/notify_device.py
@@ -1,0 +1,57 @@
+"""Notification device plugin — the reference DevicePlugin.
+
+By default it renders high/critical events as a local notification: it shells
+out to ``notify-send`` when available, otherwise logs a formatted line. Rendered
+events are also retained in ``self.rendered`` so tests and the dashboard can
+inspect what was surfaced without a display. Real output devices (sirens, GPIO
+relays, TTS — issue #29) follow this same ``render`` shape.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from typing import List
+
+from contracts import EmergencyEvent
+
+from ..base import DevicePlugin, PluginContext
+
+logger = logging.getLogger(__name__)
+
+
+class NotifyDevicePlugin(DevicePlugin):
+    def __init__(self, name: str, options=None) -> None:
+        super().__init__(name, options)
+        self.rendered: List[dict] = []
+        self._use_desktop = bool(self.options.get("desktop", True))
+        self._notify_send = shutil.which("notify-send") if self._use_desktop else None
+
+    def start(self, ctx: PluginContext) -> None:
+        logger.info(
+            "Notify device %s ready (desktop=%s)",
+            self.name,
+            bool(self._notify_send),
+        )
+
+    def render(self, event: EmergencyEvent) -> None:
+        title = f"[{event.severity.upper()}] {event.hazard_type}: {event.title}"
+        body_parts = [event.summary or event.predictive_outcome or ""]
+        location = (event.location or {}).get("name")
+        if location:
+            body_parts.append(f"Location: {location}")
+        body = " — ".join(p for p in body_parts if p)
+
+        self.rendered.append({"title": title, "body": body, "event_id": event.event_id})
+        if self._notify_send:
+            try:
+                subprocess.run(
+                    [self._notify_send, "-u", "critical", title, body],
+                    check=False,
+                    timeout=5,
+                )
+                return
+            except Exception:  # pragma: no cover - environment dependent
+                logger.debug("notify-send failed for %s; logging instead", self.name)
+        logger.warning("NOTIFY %s :: %s :: %s", self.name, title, body)

--- a/plugins/builtin/rss_source.py
+++ b/plugins/builtin/rss_source.py
@@ -1,0 +1,90 @@
+"""RSS source plugin — the reference SourcePlugin proving the ingest seam.
+
+This wraps plain RSS fetching as a first-class plugin: it returns
+:class:`~contracts.EmergencyEvent` objects built through the existing
+``normalize_event_payload`` adapter, so events produced here flow through the
+same dedup/store pipeline as the engine's native fetchers. New inbound
+transports (LoRa-in #25, MQTT-in #57, sensors #36) follow this exact pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from time import perf_counter
+from typing import List
+
+import feedparser
+import httpx
+
+from contracts import EmergencyEvent
+from utils.event_normalization import normalize_event_payload
+
+from ..base import PluginContext, SourcePlugin
+
+logger = logging.getLogger(__name__)
+
+
+class RssSourcePlugin(SourcePlugin):
+    """Fetch one or more RSS feeds listed in ``options['feeds']``."""
+
+    async def poll(self, ctx: PluginContext) -> List[EmergencyEvent]:
+        feeds = list(self.options.get("feeds", []) or [])
+        if not feeds:
+            return []
+        started = perf_counter()
+        events: List[EmergencyEvent] = []
+        config = ctx.config
+        location_name = getattr(config, "location_name", "") if config else ""
+        zip_code = getattr(config, "zip_code", None) if config else None
+        latitude = getattr(config, "latitude", None) if config else None
+        longitude = getattr(config, "longitude", None) if config else None
+
+        timeout = httpx.Timeout(self.options.get("timeout", 20))
+        try:
+            async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+                for feed_url in feeds:
+                    try:
+                        resp = await client.get(feed_url)
+                        resp.raise_for_status()
+                        parsed = await asyncio.to_thread(feedparser.parse, resp.text)
+                    except Exception as exc:
+                        logger.debug("RSS plugin %s: feed %s failed: %s", self.name, feed_url, exc)
+                        continue
+                    feed_title = parsed.feed.get("title", "RSS")
+                    for entry in parsed.entries:
+                        url = entry.get("link")
+                        if not url:
+                            continue
+                        title = entry.get("title", "(no title)")
+                        snippet = entry.get("summary", "")
+                        published = entry.get("published") or entry.get("updated")
+                        normalized = normalize_event_payload(
+                            source_event={"published_at": published, "source": feed_title},
+                            impact_score=5,
+                            is_relevant=True,
+                            location_name=location_name or "",
+                            source_kind="rss",
+                            zip_code=zip_code,
+                            latitude=latitude,
+                            longitude=longitude,
+                        )
+                        events.append(
+                            EmergencyEvent.from_normalized(
+                                normalized=normalized,
+                                title=title,
+                                snippet=snippet,
+                                impact_score=5,
+                                url=url,
+                                source=feed_title,
+                                source_kind="rss",
+                                origin_node_id=ctx.node_id,
+                            )
+                        )
+        except Exception as exc:  # pragma: no cover - network defensive
+            self.health.record_error(str(exc), latency_ms=(perf_counter() - started) * 1000)
+            return events
+        self.health.record_success(
+            latency_ms=(perf_counter() - started) * 1000, item_count=len(events)
+        )
+        return events

--- a/plugins/loader.py
+++ b/plugins/loader.py
@@ -1,0 +1,98 @@
+"""Config-driven plugin loader (plugin loader v0, issue #12).
+
+Reads the ``plugins`` list from :class:`~utils.config.AppConfig` and builds a
+started :class:`~plugins.registry.PluginRegistry`. Each entry looks like::
+
+    {"type": "rss_source", "name": "local-rss", "enabled": true,
+     "options": {"feeds": ["https://…/rss"]}}
+
+``type`` resolves against the built-in catalog, or as a ``"module:ClassName"``
+path for out-of-tree plugins — the groundwork for the richer Plugin API (#19/#40).
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import Any, List, Optional, Type
+
+from .base import Plugin
+from .builtin.mqtt_transport import MqttTransportPlugin
+from .builtin.notify_device import NotifyDevicePlugin
+from .builtin.rss_source import RssSourcePlugin
+from .registry import PluginRegistry
+
+logger = logging.getLogger(__name__)
+
+# Built-in plugin catalog: type string -> class.
+BUILTIN_PLUGINS: dict[str, Type[Plugin]] = {
+    "rss_source": RssSourcePlugin,
+    "mqtt_transport": MqttTransportPlugin,
+    "notify_device": NotifyDevicePlugin,
+}
+
+
+def resolve_plugin_class(type_name: str) -> Optional[Type[Plugin]]:
+    """Resolve a plugin ``type`` to a class, by catalog name or ``module:Class``."""
+
+    if type_name in BUILTIN_PLUGINS:
+        return BUILTIN_PLUGINS[type_name]
+    if ":" in type_name:
+        module_path, _, class_name = type_name.partition(":")
+        try:
+            module = importlib.import_module(module_path)
+            cls = getattr(module, class_name)
+        except Exception as exc:
+            logger.warning("Could not import plugin %s: %s", type_name, exc)
+            return None
+        if isinstance(cls, type) and issubclass(cls, Plugin):
+            return cls
+        logger.warning("Plugin %s is not a Plugin subclass", type_name)
+        return None
+    logger.warning("Unknown plugin type %r", type_name)
+    return None
+
+
+def build_plugin(entry: dict[str, Any]) -> Optional[Plugin]:
+    """Instantiate a single plugin from a config entry, or ``None`` if disabled/invalid."""
+
+    if not isinstance(entry, dict):
+        return None
+    if not entry.get("enabled", True):
+        return None
+    type_name = entry.get("type") or entry.get("name")
+    if not type_name:
+        logger.warning("Plugin entry missing 'type': %r", entry)
+        return None
+    cls = resolve_plugin_class(str(type_name))
+    if cls is None:
+        return None
+    name = str(entry.get("name") or type_name)
+    options = entry.get("options") or {}
+    try:
+        return cls(name=name, options=options)
+    except Exception as exc:
+        logger.warning("Failed to instantiate plugin %s: %s", name, exc)
+        return None
+
+
+def build_registry(
+    config: Any = None,
+    node_id: Optional[str] = None,
+    *,
+    start: bool = True,
+) -> PluginRegistry:
+    """Build (and by default start) a registry from ``config.plugins``."""
+
+    registry = PluginRegistry(config=config, node_id=node_id)
+    entries: List[dict[str, Any]] = []
+    if config is not None:
+        entries = list(getattr(config, "plugins", None) or [])
+    for entry in entries:
+        plugin = build_plugin(entry)
+        if plugin is not None:
+            registry.register(plugin)
+            logger.info("Loaded plugin %s (%s)", plugin.name, plugin.kind)
+    if start:
+        registry.start_all()
+    return registry

--- a/plugins/registry.py
+++ b/plugins/registry.py
@@ -1,0 +1,149 @@
+"""Plugin lifecycle + event routing registry.
+
+The registry owns the :class:`EventBus`, starts/stops plugins, wires egress
+plugins (transport/device/sink) to the bus topics they care about, and gives the
+engine two integration points: :meth:`poll_sources` (pull new events from source
+plugins each cycle) and :meth:`publish` (fan a stored event out to all egress
+plugins). It is intentionally inert when no plugins are configured, so default
+installs behave exactly as before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+from contracts import EmergencyEvent
+
+from .base import (
+    DevicePlugin,
+    EventBus,
+    Plugin,
+    PluginContext,
+    SinkPlugin,
+    SourcePlugin,
+    TransportPlugin,
+    TOPIC_HIGH,
+    TOPIC_INGEST,
+    TOPIC_NEW,
+)
+
+logger = logging.getLogger(__name__)
+
+_HIGH_SEVERITIES = {"high", "critical"}
+
+
+class PluginRegistry:
+    def __init__(self, config: Any = None, node_id: Optional[str] = None) -> None:
+        self.config = config
+        self.node_id = node_id
+        self.bus = EventBus()
+        self._plugins: List[Plugin] = []
+        self._started = False
+
+    # ----- registration / lifecycle -------------------------------------
+    def register(self, plugin: Plugin) -> None:
+        self._plugins.append(plugin)
+
+    @property
+    def plugins(self) -> List[Plugin]:
+        return list(self._plugins)
+
+    def sources(self) -> List[SourcePlugin]:
+        return [p for p in self._plugins if isinstance(p, SourcePlugin)]
+
+    def _context_for(self, plugin: Plugin) -> PluginContext:
+        return PluginContext(
+            bus=self.bus,
+            config=self.config,
+            node_id=self.node_id,
+            options=plugin.options,
+        )
+
+    def start_all(self) -> None:
+        if self._started:
+            return
+        for plugin in self._plugins:
+            try:
+                plugin.start(self._context_for(plugin))
+                self._wire_egress(plugin)
+            except Exception:
+                logger.exception("Failed to start plugin %s", plugin.name)
+                plugin.health.record_error("start failed")
+        self._started = True
+
+    def _wire_egress(self, plugin: Plugin) -> None:
+        """Subscribe egress plugins to the appropriate bus topics."""
+
+        if isinstance(plugin, TransportPlugin):
+            # Transports get every event; they decide normal vs high internally.
+            self.bus.subscribe(TOPIC_NEW, self._guard(plugin, plugin.send))
+        elif isinstance(plugin, DevicePlugin):
+            # Devices (sirens/displays) default to high-severity only; override
+            # with options {"min_severity": "low"} to receive everything.
+            topic = TOPIC_NEW if plugin.options.get("min_severity") == "low" else TOPIC_HIGH
+            self.bus.subscribe(topic, self._guard(plugin, plugin.render))
+        elif isinstance(plugin, SinkPlugin):
+            self.bus.subscribe(TOPIC_NEW, self._guard(plugin, plugin.handle))
+
+    def _guard(self, plugin: Plugin, fn: Callable[[EmergencyEvent], None]):
+        """Wrap an egress handler so it records health and never raises into the bus."""
+
+        def _handler(event: EmergencyEvent) -> None:
+            try:
+                fn(event)
+                plugin.health.record_success(item_count=1)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.exception("Plugin %s handler failed", plugin.name)
+                plugin.health.record_error(str(exc))
+
+        return _handler
+
+    def stop_all(self) -> None:
+        for plugin in self._plugins:
+            try:
+                plugin.stop()
+            except Exception:
+                logger.exception("Failed to stop plugin %s", plugin.name)
+        self._started = False
+
+    # ----- engine integration -------------------------------------------
+    async def poll_sources(self) -> List[EmergencyEvent]:
+        """Collect new events from all source plugins concurrently."""
+
+        source_plugins = self.sources()
+        if not source_plugins:
+            return []
+        ctx_map = {p: self._context_for(p) for p in source_plugins}
+        results = await asyncio.gather(
+            *[p.poll(ctx_map[p]) for p in source_plugins],
+            return_exceptions=True,
+        )
+        events: List[EmergencyEvent] = []
+        for plugin, result in zip(source_plugins, results):
+            if isinstance(result, Exception):
+                logger.warning("Source plugin %s poll failed: %s", plugin.name, result)
+                plugin.health.record_error(str(result))
+                continue
+            plugin.health.record_success(item_count=len(result))
+            events.extend(result)
+        return events
+
+    def publish(self, event: EmergencyEvent) -> None:
+        """Fan a stored event out to egress plugins (NEW, plus HIGH when severe)."""
+
+        if not self._plugins:
+            return
+        self.bus.publish(TOPIC_NEW, event)
+        if str(event.severity).lower() in _HIGH_SEVERITIES:
+            self.bus.publish(TOPIC_HIGH, event)
+
+    def subscribe_ingest(self, handler: Callable[[EmergencyEvent], None]) -> None:
+        """Register the engine's handler for inbound events from transports."""
+
+        self.bus.subscribe(TOPIC_INGEST, handler)
+
+    # ----- introspection -------------------------------------------------
+    def health(self) -> List[Dict[str, Any]]:
+        return [p.health_snapshot() for p in self._plugins]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ pgeocode
 flask
 beautifulsoup4
 psutil
+jsonschema
+paho-mqtt

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import unittest
+
+from contracts import EmergencyEvent, infer_hazard_type, new_ulid, trust
+from contracts.geohash import encode
+from utils.event_normalization import normalize_event_payload
+
+
+class EmergencyEventContractTests(unittest.TestCase):
+    def _normalized(self) -> dict:
+        return normalize_event_payload(
+            source_event={"published_at": "2026-06-19T17:58:00Z", "source": "NWS"},
+            impact_score=8,
+            is_relevant=True,
+            location_name="Mercer County, NJ",
+            source_kind="rss",
+            zip_code="08540",
+            latitude=40.34,
+            longitude=-74.65,
+        )
+
+    def test_from_normalized_upgrades_losslessly(self) -> None:
+        normalized = self._normalized()
+        event = EmergencyEvent.from_normalized(
+            normalized=normalized,
+            title="Tornado Warning issued for Mercer County",
+            snippet="Take shelter now.",
+            impact_score=8,
+            predictive_outcome="Touchdown possible within 30 minutes.",
+            url="https://example.gov/alerts/123",
+            source="NWS",
+            source_kind="rss",
+        )
+        # v1.0 fields preserved.
+        self.assertEqual(event.severity, normalized["severity"])
+        self.assertEqual(event.confidence, normalized["confidence"])
+        self.assertEqual(event.event_timestamp_utc, normalized["timestamp_utc"])
+        self.assertEqual(event.location["zip_code"], "08540")
+        # New platform fields derived.
+        self.assertEqual(event.schema_version, "2.0")
+        self.assertEqual(event.hazard_type, "tornado")
+        self.assertEqual(event.trust, "known_feed")
+        self.assertTrue(event.event_id)
+        # Geohash enrichment from coordinates.
+        self.assertEqual(event.location["geohash"], encode(40.34, -74.65))
+
+    def test_json_round_trip(self) -> None:
+        event = EmergencyEvent.from_normalized(
+            normalized=self._normalized(),
+            title="Flooding near the river",
+            snippet="Water rising",
+            impact_score=6,
+            source="County OEM",
+            source_kind="emergency_search",
+        )
+        restored = EmergencyEvent.from_json(event.to_json())
+        self.assertEqual(restored.to_dict(), event.to_dict())
+
+    def test_validate_passes_for_valid_event_and_uses_schema(self) -> None:
+        event = EmergencyEvent.from_normalized(
+            normalized=self._normalized(), title="Storm", impact_score=4
+        )
+        event.validate()  # should not raise
+
+    def test_validate_rejects_bad_values(self) -> None:
+        event = EmergencyEvent(title="x", hazard_type="not-a-hazard")
+        with self.assertRaises(ValueError):
+            event.validate()
+        event2 = EmergencyEvent(title="x", confidence=5.0)
+        with self.assertRaises(ValueError):
+            event2.validate()
+
+    def test_from_dict_ignores_unknown_fields(self) -> None:
+        event = EmergencyEvent.from_dict(
+            {"title": "t", "hazard_type": "fire", "totally_unknown": 1}
+        )
+        self.assertEqual(event.hazard_type, "fire")
+
+    def test_hazard_inference(self) -> None:
+        self.assertEqual(infer_hazard_type("Wildfire near town"), "fire")
+        self.assertEqual(infer_hazard_type("Category 4 hurricane"), "hurricane")
+        self.assertEqual(infer_hazard_type("Power outage hits grid"), "outage")
+        self.assertEqual(infer_hazard_type("Nothing notable"), "other")
+
+    def test_mesh_helpers(self) -> None:
+        event = EmergencyEvent(title="t", ttl_hops=2)
+        self.assertTrue(event.can_forward("A"))
+        event.mark_seen("A")
+        event.mark_seen("A")  # idempotent
+        self.assertEqual(event.seen_nodes, ["A"])
+        self.assertFalse(event.can_forward("A"))  # looped
+        forwarded = event.decremented()
+        self.assertEqual(forwarded.ttl_hops, 1)
+        self.assertEqual(event.ttl_hops, 2)  # original untouched
+
+    def test_ttl_zero_cannot_forward(self) -> None:
+        event = EmergencyEvent(title="t", ttl_hops=0)
+        self.assertFalse(event.can_forward("B"))
+
+    def test_trust_ordering(self) -> None:
+        self.assertGreater(trust.rank("signed_node"), trust.rank("open_search"))
+        self.assertTrue(trust.is_trusted_for_automation("authenticated_api"))
+        self.assertFalse(trust.is_trusted_for_automation("open_search"))
+
+    def test_ulid_is_sortable_and_sized(self) -> None:
+        a = new_ulid(timestamp_ms=1000)
+        b = new_ulid(timestamp_ms=2000)
+        self.assertEqual(len(a), 26)
+        self.assertLess(a, b)  # time-ordered
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from contracts import EmergencyEvent
+from plugins import EventBus, TOPIC_INGEST, TOPIC_NEW, build_registry
+from plugins.base import PluginContext, SourcePlugin
+from plugins.builtin.mqtt_transport import MqttTransportPlugin
+from plugins.builtin.notify_device import NotifyDevicePlugin
+from plugins.loader import build_plugin, resolve_plugin_class
+
+
+class FakeMqttClient:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, str]] = []
+
+    def publish(self, topic, payload):
+        self.published.append((topic, payload))
+        return type("R", (), {"rc": 0})()
+
+
+class _Cfg:
+    """Minimal config-like object exposing a plugins list."""
+
+    def __init__(self, plugins):
+        self.plugins = plugins
+        self.location_name = "Test County"
+        self.zip_code = None
+        self.latitude = None
+        self.longitude = None
+
+
+def _event(severity: str = "high") -> EmergencyEvent:
+    return EmergencyEvent(
+        title="Test hazard",
+        hazard_type="storm",
+        severity=severity,
+        confidence=0.7,
+        impact_score=8 if severity in ("high", "critical") else 3,
+    )
+
+
+class EventBusTests(unittest.TestCase):
+    def test_publish_delivers_to_subscribers(self) -> None:
+        bus = EventBus()
+        received = []
+        bus.subscribe(TOPIC_NEW, received.append)
+        delivered = bus.publish(TOPIC_NEW, _event())
+        self.assertEqual(delivered, 1)
+        self.assertEqual(len(received), 1)
+
+    def test_failing_subscriber_is_isolated(self) -> None:
+        bus = EventBus()
+        ok = []
+
+        def boom(_event):
+            raise RuntimeError("kaboom")
+
+        bus.subscribe(TOPIC_NEW, boom)
+        bus.subscribe(TOPIC_NEW, ok.append)
+        bus.publish(TOPIC_NEW, _event())  # must not raise
+        self.assertEqual(len(ok), 1)
+
+    def test_unsubscribe(self) -> None:
+        bus = EventBus()
+        received = []
+        bus.subscribe(TOPIC_NEW, received.append)
+        bus.unsubscribe(TOPIC_NEW, received.append)
+        bus.publish(TOPIC_NEW, _event())
+        self.assertEqual(received, [])
+
+
+class RegistryRoutingTests(unittest.TestCase):
+    def test_high_severity_routes_to_device_and_transport(self) -> None:
+        fake = FakeMqttClient()
+        cfg = _Cfg([
+            {"type": "mqtt_transport", "name": "bus",
+             "options": {"client": fake, "base_topic": "intel/events"}},
+            {"type": "notify_device", "name": "siren", "options": {}},
+        ])
+        registry = build_registry(cfg, node_id="NODE-A")
+        registry.publish(_event("critical"))
+
+        topics = [t for t, _ in fake.published]
+        self.assertIn("intel/events/normalized", topics)
+        self.assertIn("intel/events/high_priority", topics)
+        siren = next(p for p in registry.plugins if p.name == "siren")
+        self.assertEqual(len(siren.rendered), 1)
+
+    def test_low_severity_skips_default_device_and_high_topic(self) -> None:
+        fake = FakeMqttClient()
+        cfg = _Cfg([
+            {"type": "mqtt_transport", "name": "bus",
+             "options": {"client": fake, "base_topic": "intel/events"}},
+            {"type": "notify_device", "name": "siren", "options": {}},
+        ])
+        registry = build_registry(cfg, node_id="NODE-A")
+        registry.publish(_event("low"))
+
+        topics = [t for t, _ in fake.published]
+        self.assertEqual(topics, ["intel/events/normalized"])  # no high_priority
+        siren = next(p for p in registry.plugins if p.name == "siren")
+        self.assertEqual(siren.rendered, [])  # device defaults to high only
+
+    def test_device_min_severity_low_receives_all(self) -> None:
+        cfg = _Cfg([
+            {"type": "notify_device", "name": "log",
+             "options": {"min_severity": "low", "desktop": False}},
+        ])
+        registry = build_registry(cfg, node_id="NODE-A")
+        registry.publish(_event("low"))
+        log = registry.plugins[0]
+        self.assertEqual(len(log.rendered), 1)
+
+    def test_disabled_plugin_not_loaded(self) -> None:
+        cfg = _Cfg([
+            {"type": "notify_device", "name": "off", "enabled": False, "options": {}},
+        ])
+        registry = build_registry(cfg, node_id="NODE-A")
+        self.assertEqual(registry.plugins, [])
+
+    def test_inert_registry_with_no_plugins(self) -> None:
+        registry = build_registry(_Cfg([]), node_id="NODE-A")
+        # publish must be a no-op and never raise.
+        registry.publish(_event("critical"))
+        self.assertEqual(registry.health(), [])
+
+
+class SourcePluginPollTests(unittest.TestCase):
+    def test_poll_sources_collects_events(self) -> None:
+        class StubSource(SourcePlugin):
+            async def poll(self, ctx: PluginContext):
+                return [_event("medium"), _event("medium")]
+
+        registry = build_registry(_Cfg([]), node_id="NODE-A")
+        registry.register(StubSource("stub"))
+        events = asyncio.run(registry.poll_sources())
+        self.assertEqual(len(events), 2)
+
+    def test_poll_sources_isolates_failures(self) -> None:
+        class BadSource(SourcePlugin):
+            async def poll(self, ctx: PluginContext):
+                raise RuntimeError("nope")
+
+        class GoodSource(SourcePlugin):
+            async def poll(self, ctx: PluginContext):
+                return [_event("low")]
+
+        registry = build_registry(_Cfg([]), node_id="NODE-A")
+        registry.register(BadSource("bad"))
+        registry.register(GoodSource("good"))
+        events = asyncio.run(registry.poll_sources())
+        self.assertEqual(len(events), 1)
+
+
+class IngestSubscriptionTests(unittest.TestCase):
+    def test_inbound_events_reach_subscriber(self) -> None:
+        registry = build_registry(_Cfg([]), node_id="NODE-A")
+        got = []
+        registry.subscribe_ingest(got.append)
+        registry.bus.publish(TOPIC_INGEST, _event())
+        self.assertEqual(len(got), 1)
+
+
+class LoaderTests(unittest.TestCase):
+    def test_resolve_builtin_and_module_path(self) -> None:
+        self.assertIs(resolve_plugin_class("notify_device"), NotifyDevicePlugin)
+        cls = resolve_plugin_class(
+            "plugins.builtin.mqtt_transport:MqttTransportPlugin"
+        )
+        self.assertIs(cls, MqttTransportPlugin)
+        self.assertIsNone(resolve_plugin_class("does_not_exist"))
+
+    def test_build_plugin_respects_enabled(self) -> None:
+        self.assertIsNone(build_plugin({"type": "notify_device", "enabled": False}))
+        plugin = build_plugin({"type": "notify_device", "name": "n"})
+        self.assertIsInstance(plugin, NotifyDevicePlugin)
+
+
+class MqttTransportTests(unittest.TestCase):
+    def test_validate_before_publish(self) -> None:
+        fake = FakeMqttClient()
+        plugin = MqttTransportPlugin("bus", {"client": fake, "base_topic": "intel/events"})
+        plugin.start(PluginContext(bus=EventBus(), config=None, node_id="N"))
+        # An invalid event must be rejected before any publish happens.
+        bad = EmergencyEvent(title="x", severity="not-real")
+        with self.assertRaises(ValueError):
+            plugin.send(bad)
+        self.assertEqual(fake.published, [])
+
+    def test_published_topics_for(self) -> None:
+        plugin = MqttTransportPlugin("bus", {"base_topic": "intel/events"})
+        self.assertEqual(
+            plugin.published_topics_for(_event("low")),
+            ["intel/events/normalized"],
+        )
+        self.assertEqual(
+            plugin.published_topics_for(_event("critical")),
+            ["intel/events/normalized", "intel/events/high_priority"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_store_and_forward.py
+++ b/tests/test_store_and_forward.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from contracts import EmergencyEvent
+from mesh.forwarding import ForwardingQueue
+from mesh.node import load_or_create_node
+from utils import database
+
+
+def _event(ttl: int = 3, severity: str = "high") -> EmergencyEvent:
+    return EmergencyEvent(
+        title="Flood warning",
+        hazard_type="flood",
+        severity=severity,
+        confidence=0.8,
+        impact_score=7,
+        ttl_hops=ttl,
+    )
+
+
+class NodeIdentityTests(unittest.TestCase):
+    def test_node_id_stable_across_loads(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            n1 = load_or_create_node(base=base, role="edge", label="field-1")
+            n2 = load_or_create_node(base=base)
+            self.assertEqual(n1.node_id, n2.node_id)
+            self.assertEqual(n1.role, "edge")
+            self.assertEqual(n1.label, "field-1")
+
+    def test_invalid_role_falls_back_to_hub(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            node = load_or_create_node(base=Path(tmp), role="bogus")
+            self.assertEqual(node.role, "hub")
+
+
+class StoreAndForwardTests(unittest.TestCase):
+    def test_offer_dedup_loop_and_ttl(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("utils.database.data_dir", return_value=Path(tmp)):
+                database.init_db()
+                queue = ForwardingQueue("NODE-A")
+
+                event = _event(ttl=3)
+                result = queue.offer(event)
+                self.assertEqual(result.status, "new")
+                self.assertTrue(result.will_forward)
+                self.assertEqual(queue.pending_count(), 1)
+
+                # Forwarded copy decremented and stamped with this node.
+                forwarded = queue.pending()[0]
+                self.assertEqual(forwarded.ttl_hops, 2)
+                self.assertIn("NODE-A", forwarded.seen_nodes)
+
+                # Duplicate by event_id is suppressed.
+                dup = _event(ttl=3)
+                dup.event_id = event.event_id
+                self.assertEqual(queue.offer(dup).status, "duplicate")
+                self.assertEqual(queue.pending_count(), 1)
+
+                # Looped event (already carries this node) is suppressed.
+                looped = _event(ttl=3)
+                looped.seen_nodes = ["NODE-A"]
+                self.assertEqual(queue.offer(looped).status, "looped")
+
+                # TTL-exhausted event is accepted but not forwarded.
+                terminal = _event(ttl=0)
+                tr = queue.offer(terminal)
+                self.assertEqual(tr.status, "new")
+                self.assertFalse(tr.will_forward)
+
+    def test_survives_restart(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("utils.database.data_dir", return_value=Path(tmp)):
+                database.init_db()
+                queue = ForwardingQueue("NODE-A")
+                event = _event(ttl=2)
+                queue.offer(event)
+                forwarded_id = queue.pending()[0].event_id
+
+                # New instance on the same DB == process restart.
+                resumed = ForwardingQueue("NODE-A")
+                self.assertTrue(resumed.has_seen(event.event_id))
+                self.assertEqual(resumed.pending_count(), 1)
+
+                resumed.mark_forwarded(forwarded_id)
+                self.assertEqual(resumed.pending_count(), 0)
+                # Dedup memory persists even after the queue is drained.
+                self.assertTrue(resumed.has_seen(event.event_id))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/config.py
+++ b/utils/config.py
@@ -72,6 +72,11 @@ class AppConfig:
     context_max_current: int = 20
     context_max_historical: int = 6
     context_enable_historical: bool = True
+    # Mesh node identity (platform: emergency-services coordination).
+    node_label: Optional[str] = None
+    node_role: str = "hub"
+    # Plugin kernel: list of {type, name, enabled, options} entries.
+    plugins: List[dict] = field(default_factory=list)
 
 
 def config_dir() -> Path:
@@ -201,6 +206,9 @@ def load_config() -> AppConfig:
         context_enable_historical=_coerce_bool(
             data.get("context_enable_historical", True), True
         ),
+        node_label=data.get("node_label"),
+        node_role=str(data.get("node_role", "hub") or "hub"),
+        plugins=list(data.get("plugins", []) or []),
     )
     cfg.news_api_key = cfg.news_api_key or os.getenv("NEWS_API_KEY")
     cfg.display_timezone = cfg.display_timezone or _load_display_timezone_from_env()
@@ -257,6 +265,9 @@ def save_config(config: AppConfig) -> None:
         "context_max_current": config.context_max_current,
         "context_max_historical": config.context_max_historical,
         "context_enable_historical": config.context_enable_historical,
+        "node_label": config.node_label,
+        "node_role": config.node_role,
+        "plugins": config.plugins,
     }
     config_path().write_text(json.dumps(data, indent=2), encoding="utf-8")
     env_lines = []


### PR DESCRIPTION
## Context

VigilantCore today is a mature single-node monitor (v0.9.0): it aggregates events from RSS/news/search, dedups/normalizes, scores impact with local Ollama, and shows results in web + Qt UIs. The goal is to grow it into the **coordinating centerpiece for emergency action** — monitoring adverse events; reacting with or without internet or grid power; communicating over LoRa/Meshtastic mesh, satellite, BLE, and MQTT; informing other systems; and using local AI to fuse and prioritize.

This PR delivers **Phase 1 — Architecture & Contracts**: the foundation every later capability plugs into. It is fully **additive and backward compatible** — with no plugins configured, behavior is identical to v0.9.0.

## What's included

### `contracts/` — the canonical `EmergencyEvent` (v2.0)
A strict superset of the existing v1.0 normalized alert, so current alerts upgrade losslessly via `from_normalized()`. Adds a stable `event_id` (ULID), `origin_node_id`, `hazard_type`, `trust` tier (the #70 injection boundary), mesh `ttl_hops`/`seen_nodes`, and `actions`. Ships a JSON Schema + validator and dependency-free ULID/geohash helpers so the Python hub, the dashboard, the MQTT bus, and future Rust/Go edge daemons all agree on one shape.

### `plugins/` — the kernel
Four plugin kinds (`Source`/`Transport`/`Device`/`Sink`), an in-process `EventBus` that replaces the engine's single `on_new_alert` callback, a config-driven loader (#12), uniform health telemetry (reusing the v0.8.0 source-health shape), and three reference plugins:
- **RSS source** — proves the ingest seam
- **MQTT transport** — publishes schema-valid events to `intel/events/normalized` + `intel/events/high_priority` (#57/#58/#59/#60)
- **Notify device** — high-severity local notification

### `mesh/` — node identity + store-and-forward
Persistent `node_id` with role (`hub`/`edge`/`relay`) and a SQLite-backed store-and-forward queue implementing gossip / flood-with-suppression: duplicate and looped events suppressed, `ttl_hops` bounds flooding (#33/#34). Survives power loss. Phase 1 ships the model + reference algorithm; Phase 2's radios drive it.

### Wiring (additive, graceful degradation)
- `engine/monitor.py` — `gather_items()` pulls source plugins; `process_items()` emits each stored alert as an `EmergencyEvent` to the mesh queue and egress plugins. If an optional plugin/transport dependency is missing, monitoring still runs.
- `utils/config.py` — `node` + `plugins` config sections (existing `_coerce_*` pattern).
- `docs/architecture.md` + `docs/emergency-event-schema.md` (indexed); `requirements.txt` adds `jsonschema` + `paho-mqtt`.

## Testing
- **106 tests pass** (existing suite + 39 new: contract round-trip/schema/upgrade, event bus + registry routing + loader, store-and-forward dedup/loop/TTL/restart).
- **ruff clean** repo-wide.
- End-to-end verified: an item flows ingest → store → MQTT (both topics) → siren → forwarding queue, with stable node identity and restart-persistent dedup.

## Scope / follow-ups
Later phases land as their own PRs against these contracts: multi-channel routing (#42), LoRa/Meshtastic/BLE/satellite transports (#25–#29) + Rust/Go edge daemons with solar/power management, encrypted offline storage (#39), LLM gateway (#67), AI fusion (#35), prompt-injection hardening (#70), and event signing.

Closes #12. Lays the contract/schema groundwork for #57, #58, #59, #60. Advances #19, #40, #33, #34.