### PR TITLE
feat(contracts): EmergencyEvent contract + JSON schema (0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to VigilantCore will be documented in this file.
 
+## [0.10.0] - 2026-06-19
+
+### Added
+
+- **Canonical `EmergencyEvent` contract** (`contracts/`): the versioned (v2.0), cross-node event shape shared across the platform — the ingest pipeline, dashboard, MQTT bus, and future edge daemons. It is a strict superset of the v1.0 normalized alert, so existing alerts upgrade losslessly via `EmergencyEvent.from_normalized()`.
+  - New platform fields: stable `event_id` (ULID), `origin_node_id`, `hazard_type`, `trust` tier, mesh `ttl_hops`/`seen_nodes`, and recommended `actions`.
+  - **JSON Schema** (`contracts/emergency_event.schema.json`) with a validator that uses `jsonschema` when available and always applies cheap structural checks (so dependency-free edge nodes can validate too).
+  - Dependency-free **ULID** generation (time-sortable ids) and a **geohash** encoder for geo-routing/dedup.
+  - **Trust tiers** (`contracts/trust.py`) mapping source kinds to a provenance ordering, the boundary the AI/RAG pipeline and routing engine consult.
+- **Tests** (`tests/test_contract.py`) covering round-trip, schema validation, lossless upgrade from the normalized payload, hazard inference, mesh helpers, and trust ordering.
+- Adds `jsonschema` to requirements; documents the schema in `docs/emergency-event-schema.md`.
+
 ## [0.9.0] - 2026-06-18
 
 ### Added

--- a/contracts/__init__.py
+++ b/contracts/__init__.py
@@ -1,0 +1,32 @@
+"""Shared platform contracts for VigilantCore.
+
+The :class:`EmergencyEvent` here is the single source of truth for the event
+shape exchanged between the Python hub, the dashboard, the MQTT bus, and the
+Rust/Go edge daemons. Importing from ``contracts`` (rather than reaching into
+``utils``) is the supported way for plugins and external components to speak the
+platform's language.
+"""
+
+from __future__ import annotations
+
+from .event import (
+    EmergencyEvent,
+    HAZARD_TYPES,
+    SCHEMA_VERSION,
+    SEVERITIES,
+    infer_hazard_type,
+)
+from .ids import new_ulid
+from .schema import load_schema
+from . import trust
+
+__all__ = [
+    "EmergencyEvent",
+    "HAZARD_TYPES",
+    "SEVERITIES",
+    "SCHEMA_VERSION",
+    "infer_hazard_type",
+    "new_ulid",
+    "load_schema",
+    "trust",
+]

--- a/contracts/emergency_event.schema.json
+++ b/contracts/emergency_event.schema.json
@@ -67,12 +67,12 @@
     },
     "timestamp_utc": {
       "type": "string",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|\\+00:00)$",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,6})?(Z|\\+00:00)$",
       "description": "When this event record was observed/created (ISO-8601 UTC)."
     },
     "event_timestamp_utc": {
       "type": ["string", "null"],
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|\\+00:00)$",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,6})?(Z|\\+00:00)$",
       "description": "When the underlying hazard occurred (ISO-8601 UTC)."
     },
     "location": {

--- a/contracts/emergency_event.schema.json
+++ b/contracts/emergency_event.schema.json
@@ -23,7 +23,7 @@
     },
     "event_id": {
       "type": "string",
-      "pattern": "^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$",
+      "pattern": "^[0-9ABCDEFGHJKMNPQRSTVWXYZabcdefghjkmnpqrstvwxyz]{26}$",
       "description": "Stable 26-char Crockford base32 ULID used for cross-node dedup."
     },
     "origin_node_id": {

--- a/contracts/emergency_event.schema.json
+++ b/contracts/emergency_event.schema.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vigilant-core/contracts/emergency_event.schema.json",
+  "title": "EmergencyEvent",
+  "description": "Canonical cross-node emergency event contract for the VigilantCore platform.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_id",
+    "title",
+    "hazard_type",
+    "severity",
+    "confidence",
+    "impact_score",
+    "timestamp_utc"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "2.0"
+    },
+    "event_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable ULID used for cross-node dedup."
+    },
+    "origin_node_id": {
+      "type": ["string", "null"],
+      "description": "Node that first observed/produced the event."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "hazard_type": {
+      "type": "string",
+      "enum": [
+        "storm",
+        "hurricane",
+        "tornado",
+        "fire",
+        "flood",
+        "earthquake",
+        "outage",
+        "hazmat",
+        "conflict",
+        "transport",
+        "medical",
+        "other"
+      ]
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "impact_score": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10
+    },
+    "timestamp_utc": {
+      "type": "string",
+      "description": "When this event record was observed/created (ISO-8601 UTC)."
+    },
+    "event_timestamp_utc": {
+      "type": ["string", "null"],
+      "description": "When the underlying hazard occurred (ISO-8601 UTC)."
+    },
+    "location": {
+      "type": "object",
+      "properties": {
+        "name": {"type": ["string", "null"]},
+        "zip_code": {"type": ["string", "null"]},
+        "latitude": {"type": ["number", "null"]},
+        "longitude": {"type": ["number", "null"]},
+        "radius_km": {"type": ["number", "null"]},
+        "geohash": {"type": ["string", "null"]}
+      },
+      "additionalProperties": true
+    },
+    "summary": {"type": "string"},
+    "predictive_outcome": {"type": "string"},
+    "url": {"type": ["string", "null"]},
+    "sources": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "trust": {
+      "type": "string",
+      "enum": [
+        "untrusted",
+        "open_search",
+        "known_feed",
+        "authenticated_api",
+        "signed_node"
+      ]
+    },
+    "ttl_hops": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Remaining mesh hops; decremented on each forward (storm protection)."
+    },
+    "seen_nodes": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Nodes that have handled this event (loop prevention)."
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "kind": {"type": "string"},
+          "detail": {"type": "string"},
+          "status": {"type": "string"}
+        },
+        "additionalProperties": true
+      }
+    },
+    "signature": {
+      "type": ["string", "null"],
+      "description": "Optional Ed25519 signature over the canonical event (Phase 4)."
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/emergency_event.schema.json
+++ b/contracts/emergency_event.schema.json
@@ -12,7 +12,9 @@
     "severity",
     "confidence",
     "impact_score",
-    "timestamp_utc"
+    "timestamp_utc",
+    "ttl_hops",
+    "seen_nodes"
   ],
   "properties": {
     "schema_version": {
@@ -21,8 +23,8 @@
     },
     "event_id": {
       "type": "string",
-      "minLength": 1,
-      "description": "Stable ULID used for cross-node dedup."
+      "pattern": "^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$",
+      "description": "Stable 26-char Crockford base32 ULID used for cross-node dedup."
     },
     "origin_node_id": {
       "type": ["string", "null"],
@@ -65,10 +67,12 @@
     },
     "timestamp_utc": {
       "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|\\+00:00)$",
       "description": "When this event record was observed/created (ISO-8601 UTC)."
     },
     "event_timestamp_utc": {
       "type": ["string", "null"],
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|\\+00:00)$",
       "description": "When the underlying hazard occurred (ISO-8601 UTC)."
     },
     "location": {

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field, asdict
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Any, Mapping, Optional
 
 from . import trust as trust_tiers
@@ -65,21 +65,27 @@ REQUIRED_ON_DECODE: tuple[str, ...] = (
 # never sneak in via a range boundary. Case-insensitive for interop.
 _ULID_RE = re.compile(r"^[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26}$", re.IGNORECASE)
 
+# Canonical ISO-8601 UTC, identical to the JSON Schema pattern: a 'T' separator
+# (not a space) and an explicit UTC zone. Keeping the structural check and the
+# schema in lockstep means the no-jsonschema path accepts exactly what the schema
+# accepts — no looser, no stricter.
+_ISO_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|\+00:00)$")
+
 
 def _looks_like_ulid(value: Any) -> bool:
     return isinstance(value, str) and bool(_ULID_RE.match(value))
 
 
 def _looks_like_iso_utc(value: Any) -> bool:
-    """True if ``value`` is an ISO-8601 timestamp in UTC (``Z`` or ``+00:00``)."""
+    """True if ``value`` is a canonical ISO-8601 UTC timestamp (matching the schema)."""
 
-    if not isinstance(value, str) or not value:
+    if not isinstance(value, str) or not _ISO_UTC_RE.match(value):
         return False
     try:
-        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return False
-    return parsed.utcoffset() == timedelta(0)
+    return True
 
 # Keyword → hazard_type. First match wins; order matters (specific before generic).
 _HAZARD_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
@@ -190,6 +196,10 @@ class EmergencyEvent:
                 raise ValueError(
                     f"payload missing required field(s): {', '.join(missing)}"
                 )
+            # A required title must be a real non-empty string — reject falsy
+            # non-strings (0, False, []) before the lenient placeholder masks them.
+            if not isinstance(data.get("title"), str) or not data["title"].strip():
+                raise ValueError("title must be a non-empty string")
         known = {f for f in cls.__dataclass_fields__}  # type: ignore[attr-defined]
         filtered = {k: v for k, v in data.items() if k in known}
         # Default a missing OR present-but-empty/null title (lenient mode only;
@@ -335,8 +345,17 @@ class EmergencyEvent:
             if geo:
                 location["geohash"] = geo
 
+        # Treat a string/bytes/mapping merged_sources as a single scalar source,
+        # not an iterable of characters/keys.
+        if isinstance(merged_sources, (str, bytes, Mapping)):
+            merged_iter: tuple[Any, ...] = (merged_sources,)
+        else:
+            try:
+                merged_iter = tuple(merged_sources or ())
+            except TypeError:
+                merged_iter = (merged_sources,)
         sources: list[str] = []
-        for candidate in (source, *(merged_sources or ())):
+        for candidate in (source, *merged_iter):
             value = str(candidate or "").strip()
             if value and value not in sources:
                 sources.append(value)

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -1,0 +1,230 @@
+"""The canonical ``EmergencyEvent`` contract shared across the platform.
+
+Every component — the ingest pipeline, the dashboard, the MQTT bus, and the
+low-power Rust/Go edge daemons — agrees on this one shape. It is a strict
+superset of the v1.0 normalized alert produced by
+``utils.event_normalization.normalize_event_payload`` (see ``from_normalized``),
+so existing alerts upgrade losslessly while new fields (stable ``event_id``,
+``origin_node_id``, ``hazard_type``, ``trust``, mesh ``ttl_hops``/``seen_nodes``,
+recommended ``actions``) enable cross-node propagation, routing, and trust.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional
+
+from . import trust as trust_tiers
+from .geohash import encode_optional
+from .ids import new_ulid
+
+SCHEMA_VERSION = "2.0"
+
+# Canonical hazard taxonomy. ``other`` is the catch-all; callers should prefer a
+# specific value so routing/geo-dedup can reason about event class.
+HAZARD_TYPES: tuple[str, ...] = (
+    "storm",
+    "hurricane",
+    "tornado",
+    "fire",
+    "flood",
+    "earthquake",
+    "outage",
+    "hazmat",
+    "conflict",
+    "transport",
+    "medical",
+    "other",
+)
+
+SEVERITIES: tuple[str, ...] = ("low", "medium", "high", "critical")
+
+# Keyword → hazard_type. First match wins; order matters (specific before generic).
+_HAZARD_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("hurricane", ("hurricane", "typhoon", "cyclone")),
+    ("tornado", ("tornado", "twister", "funnel cloud")),
+    ("fire", ("wildfire", "fire", "blaze", "burn")),
+    ("flood", ("flood", "flash flood", "storm surge", "inundation")),
+    ("earthquake", ("earthquake", "quake", "seismic", "aftershock")),
+    ("outage", ("power outage", "blackout", "grid", "outage")),
+    ("hazmat", ("hazmat", "chemical spill", "gas leak", "radiation", "toxic")),
+    ("conflict", ("shooting", "explosion", "attack", "shelling", "airstrike", "conflict")),
+    ("transport", ("crash", "derailment", "collision", "pileup", "aviation", "train")),
+    ("storm", ("storm", "thunderstorm", "blizzard", "snow", "wind", "hail")),
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def infer_hazard_type(*texts: str | None) -> str:
+    """Classify a hazard from free text using the keyword taxonomy."""
+
+    haystack = " ".join(t for t in texts if t).lower()
+    if not haystack:
+        return "other"
+    for hazard, keywords in _HAZARD_KEYWORDS:
+        if any(keyword in haystack for keyword in keywords):
+            return hazard
+    return "other"
+
+
+@dataclass
+class EmergencyEvent:
+    """Platform-wide emergency event. Construct via ``from_normalized`` from the
+    ingest pipeline, or ``from_dict``/``from_json`` from a transport."""
+
+    title: str
+    schema_version: str = SCHEMA_VERSION
+    event_id: str = field(default_factory=new_ulid)
+    origin_node_id: Optional[str] = None
+    hazard_type: str = "other"
+    severity: str = "low"
+    confidence: float = 0.0
+    impact_score: int = 1
+    timestamp_utc: str = field(default_factory=_now_iso)
+    event_timestamp_utc: Optional[str] = None
+    location: dict[str, Any] = field(default_factory=dict)
+    summary: str = ""
+    predictive_outcome: str = ""
+    url: Optional[str] = None
+    sources: list[str] = field(default_factory=list)
+    trust: str = trust_tiers.DEFAULT_TRUST
+    # Mesh propagation controls (issues #33/#34).
+    ttl_hops: int = 4
+    seen_nodes: list[str] = field(default_factory=list)
+    # Recommended/dispatched response actions (routing + automation).
+    actions: list[dict[str, Any]] = field(default_factory=list)
+    # Optional Ed25519 signature, populated in Phase 4.
+    signature: Optional[str] = None
+
+    # ----- serialization -------------------------------------------------
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True, ensure_ascii=False)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "EmergencyEvent":
+        known = {f for f in cls.__dataclass_fields__}  # type: ignore[attr-defined]
+        filtered = {k: v for k, v in data.items() if k in known}
+        if "title" not in filtered:
+            filtered["title"] = data.get("title") or "(no title)"
+        return cls(**filtered)
+
+    @classmethod
+    def from_json(cls, raw: str | bytes) -> "EmergencyEvent":
+        return cls.from_dict(json.loads(raw))
+
+    # ----- mesh helpers --------------------------------------------------
+    def mark_seen(self, node_id: str) -> None:
+        """Record that ``node_id`` has handled this event (loop prevention)."""
+
+        if node_id and node_id not in self.seen_nodes:
+            self.seen_nodes.append(node_id)
+
+    def can_forward(self, node_id: str) -> bool:
+        """Whether this node should forward the event onward over the mesh."""
+
+        return self.ttl_hops > 0 and node_id not in self.seen_nodes
+
+    def decremented(self) -> "EmergencyEvent":
+        """Return a copy with one hop consumed, for forwarding to peers."""
+
+        clone = EmergencyEvent.from_dict(self.to_dict())
+        clone.ttl_hops = max(0, self.ttl_hops - 1)
+        return clone
+
+    # ----- validation ----------------------------------------------------
+    def validate(self) -> None:
+        """Raise ``ValueError`` if the event violates the contract invariants.
+
+        Uses ``jsonschema`` against the bundled schema when available, and always
+        applies the cheap structural checks so validation works on dependency-free
+        edge nodes too.
+        """
+
+        if not self.title:
+            raise ValueError("title is required")
+        if self.hazard_type not in HAZARD_TYPES:
+            raise ValueError(f"invalid hazard_type: {self.hazard_type!r}")
+        if self.severity not in SEVERITIES:
+            raise ValueError(f"invalid severity: {self.severity!r}")
+        if not 0.0 <= float(self.confidence) <= 1.0:
+            raise ValueError("confidence must be within [0, 1]")
+        if not 1 <= int(self.impact_score) <= 10:
+            raise ValueError("impact_score must be within [1, 10]")
+        if self.ttl_hops < 0:
+            raise ValueError("ttl_hops must be non-negative")
+        if self.trust not in trust_tiers.TRUST_TIERS:
+            raise ValueError(f"invalid trust tier: {self.trust!r}")
+
+        try:
+            import jsonschema  # type: ignore
+        except Exception:
+            return
+        from .schema import load_schema
+
+        jsonschema.validate(self.to_dict(), load_schema())
+
+    # ----- adapter from the existing pipeline ----------------------------
+    @classmethod
+    def from_normalized(
+        cls,
+        *,
+        normalized: Mapping[str, Any],
+        title: str,
+        snippet: str = "",
+        impact_score: Any = 1,
+        predictive_outcome: str = "",
+        url: Optional[str] = None,
+        source: Optional[str] = None,
+        source_kind: Optional[str] = None,
+        merged_sources: Any = (),
+        origin_node_id: Optional[str] = None,
+        hazard_type: Optional[str] = None,
+        trust: Optional[str] = None,
+    ) -> "EmergencyEvent":
+        """Build an ``EmergencyEvent`` from ``normalize_event_payload`` output.
+
+        ``normalized`` is the dict returned by
+        ``utils.event_normalization.normalize_event_payload`` (severity,
+        confidence, timestamp_utc, location). All v1.0 fields are preserved; the
+        new platform fields are derived or defaulted.
+        """
+
+        location = dict(normalized.get("location") or {})
+        # Enrich location with a geohash for geo-routing/dedup when coords exist.
+        if "geohash" not in location:
+            geo = encode_optional(location.get("latitude"), location.get("longitude"))
+            if geo:
+                location["geohash"] = geo
+
+        sources: list[str] = []
+        for candidate in (source, *(merged_sources or ())):
+            value = str(candidate or "").strip()
+            if value and value not in sources:
+                sources.append(value)
+
+        resolved_trust = trust or trust_tiers.for_source_kind(source_kind)
+        resolved_hazard = hazard_type or infer_hazard_type(title, snippet)
+
+        return cls(
+            title=title or "(no title)",
+            origin_node_id=origin_node_id,
+            hazard_type=resolved_hazard,
+            severity=str(normalized.get("severity", "low")),
+            confidence=float(normalized.get("confidence", 0.0) or 0.0),
+            impact_score=max(1, min(10, int(impact_score or 1))),
+            event_timestamp_utc=normalized.get("timestamp_utc"),
+            location=location,
+            summary=snippet or "",
+            predictive_outcome=predictive_outcome or "",
+            url=url,
+            sources=sources or ["Unknown"],
+            trust=resolved_trust,
+        )

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -257,8 +257,8 @@ class EmergencyEvent:
         ``ValueError`` — never ``TypeError`` — even for malformed parsed JSON.
         """
 
-        if not self.title:
-            raise ValueError("title is required")
+        if not isinstance(self.title, str) or not self.title.strip():
+            raise ValueError("title must be a non-empty string")
         if self.schema_version != SCHEMA_VERSION:
             raise ValueError(
                 f"unsupported schema_version: {self.schema_version!r} (expected {SCHEMA_VERSION})"
@@ -312,6 +312,11 @@ class EmergencyEvent:
             jsonschema.validate(self.to_dict(), schema)
         except jsonschema.ValidationError as exc:
             raise ValueError(f"schema validation failed: {exc.message}") from exc
+        except jsonschema.exceptions.SchemaError:
+            # The bundled schema itself is corrupt — an internal problem, not an
+            # invalid event. The comprehensive structural checks above already
+            # cover the contract, so degrade rather than leak a non-ValueError.
+            return
 
     # ----- adapter from the existing pipeline ----------------------------
     @classmethod

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -41,6 +41,20 @@ HAZARD_TYPES: tuple[str, ...] = (
 
 SEVERITIES: tuple[str, ...] = ("low", "medium", "high", "critical")
 
+# Fields a payload received from another node must carry explicitly. We refuse to
+# mint these on decode (see ``from_dict(strict=True)``) because inventing an
+# identity/timestamp would corrupt cross-node dedup and loop detection.
+REQUIRED_ON_DECODE: tuple[str, ...] = (
+    "schema_version",
+    "event_id",
+    "title",
+    "timestamp_utc",
+    "hazard_type",
+    "severity",
+    "confidence",
+    "impact_score",
+)
+
 # Keyword → hazard_type. First match wins; order matters (specific before generic).
 _HAZARD_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("hurricane", ("hurricane", "typhoon", "cyclone")),
@@ -127,7 +141,25 @@ class EmergencyEvent:
         return json.dumps(self.to_dict(), sort_keys=True, ensure_ascii=False)
 
     @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> "EmergencyEvent":
+    def from_dict(cls, data: Mapping[str, Any], *, strict: bool = False) -> "EmergencyEvent":
+        """Build an event from a mapping.
+
+        With ``strict=True`` (the default for :meth:`from_json`, i.e. decoding a
+        payload received from another node), required fields must be present and
+        non-empty — we refuse to *mint* a missing ``event_id`` or ``timestamp_utc``
+        on decode, since inventing identities would corrupt cross-node dedup and
+        loop detection. Lenient mode (the default here) is for locally-constructed
+        events, where defaults like a fresh ULID are intended.
+        """
+
+        if not isinstance(data, Mapping):
+            raise ValueError("event payload must be a JSON object")
+        if strict:
+            missing = [k for k in REQUIRED_ON_DECODE if data.get(k) in (None, "")]
+            if missing:
+                raise ValueError(
+                    f"payload missing required field(s): {', '.join(missing)}"
+                )
         known = {f for f in cls.__dataclass_fields__}  # type: ignore[attr-defined]
         filtered = {k: v for k, v in data.items() if k in known}
         if "title" not in filtered:
@@ -135,8 +167,15 @@ class EmergencyEvent:
         return cls(**filtered)
 
     @classmethod
-    def from_json(cls, raw: str | bytes) -> "EmergencyEvent":
-        return cls.from_dict(json.loads(raw))
+    def from_json(cls, raw: str | bytes, *, strict: bool = True) -> "EmergencyEvent":
+        """Decode an event from JSON. Strict by default: payloads from transports
+        that omit required fields are rejected, not silently completed."""
+
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise ValueError(f"invalid event JSON: {exc}") from exc
+        return cls.from_dict(data, strict=strict)
 
     # ----- mesh helpers --------------------------------------------------
     def mark_seen(self, node_id: str) -> None:
@@ -191,6 +230,13 @@ class EmergencyEvent:
             raise ValueError("ttl_hops must be non-negative")
         if self.trust not in trust_tiers.TRUST_TIERS:
             raise ValueError(f"invalid trust tier: {self.trust!r}")
+        # Structured-field shapes (caught here so the no-jsonschema path doesn't
+        # accept e.g. seen_nodes="nodeA", which would crash mark_seen() later).
+        if not isinstance(self.location, dict):
+            raise ValueError("location must be an object")
+        for field_name in ("sources", "seen_nodes", "actions"):
+            if not isinstance(getattr(self, field_name), list):
+                raise ValueError(f"{field_name} must be a list")
 
         # Optional deep validation against the bundled JSON Schema, when present.
         try:

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -60,6 +60,24 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
+def _as_float(value: Any, field_name: str) -> float:
+    """Coerce to float, raising ``ValueError`` (not ``TypeError``) on bad input."""
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{field_name} must be a number") from None
+
+
+def _as_int(value: Any, field_name: str) -> int:
+    """Coerce to int, raising ``ValueError`` (not ``TypeError``) on bad input."""
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{field_name} must be an integer") from None
+
+
 def infer_hazard_type(*texts: str | None) -> str:
     """Classify a hazard from free text using the keyword taxonomy."""
 
@@ -143,33 +161,53 @@ class EmergencyEvent:
     def validate(self) -> None:
         """Raise ``ValueError`` if the event violates the contract invariants.
 
-        Uses ``jsonschema`` against the bundled schema when available, and always
-        applies the cheap structural checks so validation works on dependency-free
-        edge nodes too.
+        The structural checks below fully cover the schema's required invariants
+        and always run, so validation is correct even on dependency-free edge
+        nodes (no ``jsonschema``) and in packaged builds where the schema file may
+        not be bundled. When ``jsonschema`` *is* available, the bundled schema is
+        additionally enforced as a deep check. Every failure path raises
+        ``ValueError`` — never ``TypeError`` — even for malformed parsed JSON.
         """
 
         if not self.title:
             raise ValueError("title is required")
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported schema_version: {self.schema_version!r} (expected {SCHEMA_VERSION})"
+            )
+        if not self.event_id:
+            raise ValueError("event_id is required")
+        if not self.timestamp_utc:
+            raise ValueError("timestamp_utc is required")
         if self.hazard_type not in HAZARD_TYPES:
             raise ValueError(f"invalid hazard_type: {self.hazard_type!r}")
         if self.severity not in SEVERITIES:
             raise ValueError(f"invalid severity: {self.severity!r}")
-        if not 0.0 <= float(self.confidence) <= 1.0:
+        if not 0.0 <= _as_float(self.confidence, "confidence") <= 1.0:
             raise ValueError("confidence must be within [0, 1]")
-        if not 1 <= int(self.impact_score) <= 10:
+        if not 1 <= _as_int(self.impact_score, "impact_score") <= 10:
             raise ValueError("impact_score must be within [1, 10]")
-        if self.ttl_hops < 0:
+        if _as_int(self.ttl_hops, "ttl_hops") < 0:
             raise ValueError("ttl_hops must be non-negative")
         if self.trust not in trust_tiers.TRUST_TIERS:
             raise ValueError(f"invalid trust tier: {self.trust!r}")
 
+        # Optional deep validation against the bundled JSON Schema, when present.
         try:
             import jsonschema  # type: ignore
-        except Exception:
+        except ImportError:
             return
-        from .schema import load_schema
+        try:
+            from .schema import load_schema
 
-        jsonschema.validate(self.to_dict(), load_schema())
+            schema = load_schema()
+        except FileNotFoundError:
+            # Schema not bundled (e.g. packaged build); structural checks suffice.
+            return
+        try:
+            jsonschema.validate(self.to_dict(), schema)
+        except jsonschema.ValidationError as exc:
+            raise ValueError(f"schema validation failed: {exc.message}") from exc
 
     # ----- adapter from the existing pipeline ----------------------------
     @classmethod
@@ -188,13 +226,17 @@ class EmergencyEvent:
         origin_node_id: Optional[str] = None,
         hazard_type: Optional[str] = None,
         trust: Optional[str] = None,
+        event_timestamp_utc: Optional[str] = None,
     ) -> "EmergencyEvent":
         """Build an ``EmergencyEvent`` from ``normalize_event_payload`` output.
 
         ``normalized`` is the dict returned by
         ``utils.event_normalization.normalize_event_payload`` (severity,
-        confidence, timestamp_utc, location). All v1.0 fields are preserved; the
-        new platform fields are derived or defaulted.
+        confidence, timestamp_utc, location). The upgrade is lossless: the v1
+        ``timestamp_utc`` (the published/observed time) is preserved verbatim in
+        ``timestamp_utc``. ``event_timestamp_utc`` (when the hazard itself
+        occurred) is left unset unless the caller explicitly supplies one, since
+        the normalized payload carries only the observed time.
         """
 
         location = dict(normalized.get("location") or {})
@@ -220,7 +262,8 @@ class EmergencyEvent:
             severity=str(normalized.get("severity", "low")),
             confidence=float(normalized.get("confidence", 0.0) or 0.0),
             impact_score=max(1, min(10, int(impact_score or 1))),
-            event_timestamp_utc=normalized.get("timestamp_utc"),
+            timestamp_utc=normalized.get("timestamp_utc") or _now_iso(),
+            event_timestamp_utc=event_timestamp_utc,
             location=location,
             summary=snippet or "",
             predictive_outcome=predictive_outcome or "",

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -60,8 +60,10 @@ REQUIRED_ON_DECODE: tuple[str, ...] = (
     "seen_nodes",
 )
 
-# A ULID is 26 Crockford base32 chars (excludes I, L, O, U); accept either case.
-_ULID_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$", re.IGNORECASE)
+# A ULID is 26 Crockford base32 chars. Enumerate the alphabet explicitly (the
+# same set as contracts.ids._CROCKFORD) rather than using ranges, so I/L/O/U can
+# never sneak in via a range boundary. Case-insensitive for interop.
+_ULID_RE = re.compile(r"^[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26}$", re.IGNORECASE)
 
 
 def _looks_like_ulid(value: Any) -> bool:
@@ -342,13 +344,20 @@ class EmergencyEvent:
         resolved_trust = trust or trust_tiers.for_source_kind(source_kind)
         resolved_hazard = hazard_type or infer_hazard_type(title, snippet)
 
+        # Coerce impact_score defensively: callers may pass through unparsed
+        # values, and from_normalized() must not raise while building an event.
+        try:
+            score = int(impact_score)
+        except (TypeError, ValueError):
+            score = 1
+
         return cls(
             title=title or "(no title)",
             origin_node_id=origin_node_id,
             hazard_type=resolved_hazard,
             severity=str(normalized.get("severity", "low")),
             confidence=float(normalized.get("confidence", 0.0) or 0.0),
-            impact_score=max(1, min(10, int(impact_score or 1))),
+            impact_score=max(1, min(10, score)),
             timestamp_utc=normalized.get("timestamp_utc") or _now_iso(),
             event_timestamp_utc=event_timestamp_utc,
             location=location,

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -287,9 +287,14 @@ class EmergencyEvent:
         # accept e.g. seen_nodes="nodeA", which would crash mark_seen() later).
         if not isinstance(self.location, dict):
             raise ValueError("location must be an object")
-        for field_name in ("sources", "seen_nodes", "actions"):
-            if not isinstance(getattr(self, field_name), list):
-                raise ValueError(f"{field_name} must be a list")
+        for field_name in ("sources", "seen_nodes"):
+            value = getattr(self, field_name)
+            if not isinstance(value, list) or not all(isinstance(s, str) for s in value):
+                raise ValueError(f"{field_name} must be a list of strings")
+        if not isinstance(self.actions, list) or not all(
+            isinstance(a, dict) for a in self.actions
+        ):
+            raise ValueError("actions must be a list of objects")
 
         # Optional deep validation against the bundled JSON Schema, when present.
         try:

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -202,9 +202,11 @@ class EmergencyEvent:
                 raise ValueError("title must be a non-empty string")
         known = {f for f in cls.__dataclass_fields__}  # type: ignore[attr-defined]
         filtered = {k: v for k, v in data.items() if k in known}
-        # Default a missing OR present-but-empty/null title (lenient mode only;
-        # strict decode already rejects an empty required title above).
-        if not filtered.get("title"):
+        # Default only a missing/null title or an empty/whitespace string (lenient
+        # mode). A non-string falsy value (0, False, []) is preserved rather than
+        # masked with the placeholder, so a later validate() can still reject it.
+        title_val = filtered.get("title")
+        if title_val is None or (isinstance(title_val, str) and not title_val.strip()):
             filtered["title"] = "(no title)"
         event = cls(**filtered)
         if strict:
@@ -295,6 +297,14 @@ class EmergencyEvent:
             isinstance(a, dict) for a in self.actions
         ):
             raise ValueError("actions must be a list of objects")
+        # Contractual string fields (schema: string, or string|null for optionals).
+        for field_name in ("summary", "predictive_outcome"):
+            if not isinstance(getattr(self, field_name), str):
+                raise ValueError(f"{field_name} must be a string")
+        for field_name in ("origin_node_id", "url", "signature"):
+            value = getattr(self, field_name)
+            if value is not None and not isinstance(value, str):
+                raise ValueError(f"{field_name} must be a string or null")
 
         # Optional deep validation against the bundled JSON Schema, when present.
         try:

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -171,11 +171,13 @@ class EmergencyEvent:
         """Build an event from a mapping.
 
         With ``strict=True`` (the default for :meth:`from_json`, i.e. decoding a
-        payload received from another node), required fields must be present and
-        non-empty — we refuse to *mint* a missing ``event_id`` or ``timestamp_utc``
-        on decode, since inventing identities would corrupt cross-node dedup and
-        loop detection. Lenient mode (the default here) is for locally-constructed
-        events, where defaults like a fresh ULID are intended.
+        payload received from another node), the payload must carry every required
+        field and pass full :meth:`validate` — we refuse to *mint* a missing
+        ``event_id``/``timestamp_utc``/mesh-state on decode, and we reject
+        malformed values (e.g. ``ttl_hops="1"`` or a non-ULID id) up front so the
+        ``ValueError`` guarantee holds before any downstream mesh op runs. Lenient
+        mode (the default here) is for locally-constructed events, where defaults
+        like a fresh ULID are intended.
         """
 
         if not isinstance(data, Mapping):
@@ -190,7 +192,10 @@ class EmergencyEvent:
         filtered = {k: v for k, v in data.items() if k in known}
         if "title" not in filtered:
             filtered["title"] = data.get("title") or "(no title)"
-        return cls(**filtered)
+        event = cls(**filtered)
+        if strict:
+            event.validate()
+        return event
 
     @classmethod
     def from_json(cls, raw: str | bytes, *, strict: bool = True) -> "EmergencyEvent":

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -190,8 +190,10 @@ class EmergencyEvent:
                 )
         known = {f for f in cls.__dataclass_fields__}  # type: ignore[attr-defined]
         filtered = {k: v for k, v in data.items() if k in known}
-        if "title" not in filtered:
-            filtered["title"] = data.get("title") or "(no title)"
+        # Default a missing OR present-but-empty/null title (lenient mode only;
+        # strict decode already rejects an empty required title above).
+        if not filtered.get("title"):
+            filtered["title"] = "(no title)"
         event = cls(**filtered)
         if strict:
             # Unauthenticated transport: a sender must not self-declare a tier

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -74,22 +74,24 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
-def _as_float(value: Any, field_name: str) -> float:
-    """Coerce to float, raising ``ValueError`` (not ``TypeError``) on bad input."""
+def _require_number(value: Any, field_name: str) -> float:
+    """Return ``value`` as float, raising ``ValueError`` unless it is a real
+    number. Rejects strings/None/bool so the no-``jsonschema`` path does not
+    accept e.g. ``confidence="0.5"`` and leave a non-numeric on the object."""
 
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        raise ValueError(f"{field_name} must be a number") from None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field_name} must be a number, got {type(value).__name__}")
+    return float(value)
 
 
-def _as_int(value: Any, field_name: str) -> int:
-    """Coerce to int, raising ``ValueError`` (not ``TypeError``) on bad input."""
+def _require_int(value: Any, field_name: str) -> int:
+    """Return ``value`` if it is a real int, raising ``ValueError`` otherwise.
+    Rejects numeric strings/None/bool so downstream integer ops (e.g.
+    ``ttl_hops > 0`` in ``can_forward()``) cannot raise ``TypeError``."""
 
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        raise ValueError(f"{field_name} must be an integer") from None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field_name} must be an integer, got {type(value).__name__}")
+    return value
 
 
 def infer_hazard_type(*texts: str | None) -> str:
@@ -222,11 +224,11 @@ class EmergencyEvent:
             raise ValueError(f"invalid hazard_type: {self.hazard_type!r}")
         if self.severity not in SEVERITIES:
             raise ValueError(f"invalid severity: {self.severity!r}")
-        if not 0.0 <= _as_float(self.confidence, "confidence") <= 1.0:
+        if not 0.0 <= _require_number(self.confidence, "confidence") <= 1.0:
             raise ValueError("confidence must be within [0, 1]")
-        if not 1 <= _as_int(self.impact_score, "impact_score") <= 10:
+        if not 1 <= _require_int(self.impact_score, "impact_score") <= 10:
             raise ValueError("impact_score must be within [1, 10]")
-        if _as_int(self.ttl_hops, "ttl_hops") < 0:
+        if _require_int(self.ttl_hops, "ttl_hops") < 0:
             raise ValueError("ttl_hops must be non-negative")
         if self.trust not in trust_tiers.TRUST_TIERS:
             raise ValueError(f"invalid trust tier: {self.trust!r}")

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -69,7 +69,7 @@ _ULID_RE = re.compile(r"^[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26}$", re.IGNORECASE)
 # (not a space) and an explicit UTC zone. Keeping the structural check and the
 # schema in lockstep means the no-jsonschema path accepts exactly what the schema
 # accepts — no looser, no stricter.
-_ISO_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|\+00:00)$")
+_ISO_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?(Z|\+00:00)$")
 
 
 def _looks_like_ulid(value: Any) -> bool:

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -12,8 +12,9 @@ recommended ``actions``) enable cross-node propagation, routing, and trust.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass, field, asdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping, Optional
 
 from . import trust as trust_tiers
@@ -43,7 +44,9 @@ SEVERITIES: tuple[str, ...] = ("low", "medium", "high", "critical")
 
 # Fields a payload received from another node must carry explicitly. We refuse to
 # mint these on decode (see ``from_dict(strict=True)``) because inventing an
-# identity/timestamp would corrupt cross-node dedup and loop detection.
+# identity/timestamp/mesh-state would corrupt cross-node dedup and loop/storm
+# protection (a missing ttl_hops/seen_nodes would otherwise default to a fresh,
+# full-TTL, empty-path event and re-admit an exhausted or looping message).
 REQUIRED_ON_DECODE: tuple[str, ...] = (
     "schema_version",
     "event_id",
@@ -53,7 +56,28 @@ REQUIRED_ON_DECODE: tuple[str, ...] = (
     "severity",
     "confidence",
     "impact_score",
+    "ttl_hops",
+    "seen_nodes",
 )
+
+# A ULID is 26 Crockford base32 chars (excludes I, L, O, U); accept either case.
+_ULID_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$", re.IGNORECASE)
+
+
+def _looks_like_ulid(value: Any) -> bool:
+    return isinstance(value, str) and bool(_ULID_RE.match(value))
+
+
+def _looks_like_iso_utc(value: Any) -> bool:
+    """True if ``value`` is an ISO-8601 timestamp in UTC (``Z`` or ``+00:00``)."""
+
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return parsed.utcoffset() == timedelta(0)
 
 # Keyword → hazard_type. First match wins; order matters (specific before generic).
 _HAZARD_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
@@ -216,10 +240,14 @@ class EmergencyEvent:
             raise ValueError(
                 f"unsupported schema_version: {self.schema_version!r} (expected {SCHEMA_VERSION})"
             )
-        if not self.event_id:
-            raise ValueError("event_id is required")
-        if not self.timestamp_utc:
-            raise ValueError("timestamp_utc is required")
+        if not _looks_like_ulid(self.event_id):
+            raise ValueError("event_id must be a 26-character ULID")
+        if not _looks_like_iso_utc(self.timestamp_utc):
+            raise ValueError("timestamp_utc must be an ISO-8601 UTC timestamp")
+        if self.event_timestamp_utc is not None and not _looks_like_iso_utc(
+            self.event_timestamp_utc
+        ):
+            raise ValueError("event_timestamp_utc must be an ISO-8601 UTC timestamp")
         if self.hazard_type not in HAZARD_TYPES:
             raise ValueError(f"invalid hazard_type: {self.hazard_type!r}")
         if self.severity not in SEVERITIES:

--- a/contracts/event.py
+++ b/contracts/event.py
@@ -194,6 +194,10 @@ class EmergencyEvent:
             filtered["title"] = data.get("title") or "(no title)"
         event = cls(**filtered)
         if strict:
+            # Unauthenticated transport: a sender must not self-declare a tier
+            # above the unverified ceiling (Phase 4 signature verification will
+            # lift this for events that prove it).
+            event.trust = trust_tiers.cap_unverified(event.trust)
             event.validate()
         return event
 

--- a/contracts/geohash.py
+++ b/contracts/geohash.py
@@ -1,0 +1,63 @@
+"""Minimal, dependency-free geohash encoder.
+
+Geohashes turn a lat/lon into a short string where a shared prefix implies
+spatial proximity. The platform uses them for cheap geo-routing and cross-node
+spatial dedup (events about the same area share a geohash prefix) without
+pulling in a geospatial library on low-power field nodes.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+_BASE32 = "0123456789bcdefghjkmnpqrstuvwxyz"
+
+
+def encode(latitude: float, longitude: float, precision: int = 7) -> str:
+    """Encode a coordinate to a geohash of the given precision (default 7 ~= 153m)."""
+
+    lat_range = [-90.0, 90.0]
+    lon_range = [-180.0, 180.0]
+    geohash: list[str] = []
+    bits = [16, 8, 4, 2, 1]
+    bit = 0
+    ch = 0
+    even = True
+
+    while len(geohash) < precision:
+        if even:
+            mid = (lon_range[0] + lon_range[1]) / 2
+            if longitude > mid:
+                ch |= bits[bit]
+                lon_range[0] = mid
+            else:
+                lon_range[1] = mid
+        else:
+            mid = (lat_range[0] + lat_range[1]) / 2
+            if latitude > mid:
+                ch |= bits[bit]
+                lat_range[0] = mid
+            else:
+                lat_range[1] = mid
+        even = not even
+        if bit < 4:
+            bit += 1
+        else:
+            geohash.append(_BASE32[ch])
+            bit = 0
+            ch = 0
+
+    return "".join(geohash)
+
+
+def encode_optional(
+    latitude: Optional[float], longitude: Optional[float], precision: int = 7
+) -> Optional[str]:
+    """Encode only when both coordinates are present; otherwise return ``None``."""
+
+    if latitude is None or longitude is None:
+        return None
+    try:
+        return encode(float(latitude), float(longitude), precision)
+    except (TypeError, ValueError):
+        return None

--- a/contracts/ids.py
+++ b/contracts/ids.py
@@ -1,0 +1,38 @@
+"""Dependency-free ULID generation for cross-node identifiers.
+
+ULIDs are 26-character Crockford base32 strings whose leading 48 bits encode a
+millisecond timestamp, so they sort lexicographically by creation time. That
+time-ordering is what lets the store-and-forward queue and cross-node dedup
+(``event_id``) work without a central clock or coordinator.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+# Crockford base32 alphabet (excludes I, L, O, U to avoid transcription errors).
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+
+def _encode_base32(value: int, length: int) -> str:
+    chars = []
+    for _ in range(length):
+        value, rem = divmod(value, 32)
+        chars.append(_CROCKFORD[rem])
+    return "".join(reversed(chars))
+
+
+def new_ulid(timestamp_ms: int | None = None) -> str:
+    """Return a new 26-character ULID.
+
+    ``timestamp_ms`` may be supplied for deterministic tests; otherwise the
+    current wall-clock time is used. Randomness comes from ``os.urandom`` so the
+    result is unguessable across nodes.
+    """
+
+    if timestamp_ms is None:
+        timestamp_ms = int(time.time() * 1000)
+    timestamp_ms &= (1 << 48) - 1
+    randomness = int.from_bytes(os.urandom(10), "big")  # 80 bits
+    return _encode_base32(timestamp_ms, 10) + _encode_base32(randomness, 16)

--- a/contracts/schema.py
+++ b/contracts/schema.py
@@ -3,15 +3,32 @@
 from __future__ import annotations
 
 import json
+import sys
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-SCHEMA_PATH = Path(__file__).with_name("emergency_event.schema.json")
+SCHEMA_FILENAME = "emergency_event.schema.json"
+
+
+def schema_path() -> Path:
+    """Resolve the schema file, honoring PyInstaller's bundle dir when frozen.
+
+    A ``--onefile`` build unpacks bundled data under ``sys._MEIPASS``; fall back
+    to the source-relative path for normal runs. Callers should be prepared for
+    ``FileNotFoundError`` if a packaged build did not include the data file.
+    """
+
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        bundled = Path(meipass) / "contracts" / SCHEMA_FILENAME
+        if bundled.exists():
+            return bundled
+    return Path(__file__).with_name(SCHEMA_FILENAME)
 
 
 @lru_cache(maxsize=1)
 def load_schema() -> dict[str, Any]:
     """Return the parsed EmergencyEvent JSON Schema (cached)."""
 
-    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    return json.loads(schema_path().read_text(encoding="utf-8"))

--- a/contracts/schema.py
+++ b/contracts/schema.py
@@ -1,0 +1,17 @@
+"""Loader for the bundled EmergencyEvent JSON Schema."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+SCHEMA_PATH = Path(__file__).with_name("emergency_event.schema.json")
+
+
+@lru_cache(maxsize=1)
+def load_schema() -> dict[str, Any]:
+    """Return the parsed EmergencyEvent JSON Schema (cached)."""
+
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))

--- a/contracts/trust.py
+++ b/contracts/trust.py
@@ -25,11 +25,15 @@ TRUST_TIERS: tuple[str, ...] = (
 # their own tier explicitly when they emit events.
 SOURCE_KIND_TRUST: dict[str, str] = {
     "rss": "known_feed",
-    "emergency_search": "known_feed",
     "news_api": "authenticated_api",
     "google_cse": "open_search",
     "bing_search": "open_search",
     "duckduckgo": "open_search",
+    # emergency_search resolves to open-web (DuckDuckGo) queries via
+    # utils.sources.search_emergency_info, so it is open_search — NOT a curated
+    # feed. Classifying it higher would let open-web content cross the trust
+    # boundary used for automation and prompt-injection defense (issue #70).
+    "emergency_search": "open_search",
 }
 
 DEFAULT_TRUST = "open_search"

--- a/contracts/trust.py
+++ b/contracts/trust.py
@@ -1,0 +1,56 @@
+"""Provenance trust tiers for the EmergencyEvent contract.
+
+Trust is the trust boundary the AI/RAG pipeline (issue #70) and the routing
+engine both consult: higher-trust events may be acted on automatically and are
+preferred when channels are contended, while lower-trust content (open web
+search, unauthenticated mesh) must be treated as untrusted input and never be
+allowed to inject instructions into LLM prompts.
+
+The tiers are ordered; ``rank()`` gives a comparable integer (higher = more
+trusted) so callers can threshold or sort without hard-coding the strings.
+"""
+
+from __future__ import annotations
+
+# Ordered from least to most trusted.
+TRUST_TIERS: tuple[str, ...] = (
+    "untrusted",          # unsolicited / unauthenticated mesh or user-pasted content
+    "open_search",        # open web search results (DuckDuckGo, CSE, Bing)
+    "known_feed",         # curated RSS / agency feeds
+    "authenticated_api",  # keyed API (NewsAPI) or authenticated MQTT peer
+    "signed_node",        # cryptographically signed event from a known node (Phase 4)
+)
+
+# Map each existing source_kind to its default trust tier. New transports register
+# their own tier explicitly when they emit events.
+SOURCE_KIND_TRUST: dict[str, str] = {
+    "rss": "known_feed",
+    "emergency_search": "known_feed",
+    "news_api": "authenticated_api",
+    "google_cse": "open_search",
+    "bing_search": "open_search",
+    "duckduckgo": "open_search",
+}
+
+DEFAULT_TRUST = "open_search"
+
+
+def rank(tier: str | None) -> int:
+    """Return a comparable rank for a trust tier (higher = more trusted)."""
+
+    try:
+        return TRUST_TIERS.index((tier or "").strip().lower())
+    except ValueError:
+        return TRUST_TIERS.index(DEFAULT_TRUST)
+
+
+def for_source_kind(source_kind: str | None) -> str:
+    """Best-effort trust tier for a legacy ``source_kind`` string."""
+
+    return SOURCE_KIND_TRUST.get((source_kind or "").strip().lower(), DEFAULT_TRUST)
+
+
+def is_trusted_for_automation(tier: str | None, *, minimum: str = "known_feed") -> bool:
+    """Whether an event at ``tier`` is trusted enough to drive automated actions."""
+
+    return rank(tier) >= rank(minimum)

--- a/contracts/trust.py
+++ b/contracts/trust.py
@@ -78,7 +78,11 @@ def cap_unverified(tier: str | None) -> str:
     trust for events that actually prove it.
     """
 
-    normalized = (tier or "").strip().lower()
+    if not isinstance(tier, str):
+        # Non-string (e.g. JSON number/array): leave it unchanged so the caller's
+        # validate() rejects it with ValueError rather than crashing here.
+        return tier
+    normalized = tier.strip().lower()
     if rank(normalized) > rank(UNVERIFIED_CEILING):
         return UNVERIFIED_CEILING
     return normalized if normalized in TRUST_TIERS else DEFAULT_TRUST

--- a/contracts/trust.py
+++ b/contracts/trust.py
@@ -78,6 +78,7 @@ def cap_unverified(tier: str | None) -> str:
     trust for events that actually prove it.
     """
 
-    if rank(tier) > rank(UNVERIFIED_CEILING):
+    normalized = (tier or "").strip().lower()
+    if rank(normalized) > rank(UNVERIFIED_CEILING):
         return UNVERIFIED_CEILING
-    return tier if tier in TRUST_TIERS else DEFAULT_TRUST
+    return normalized if normalized in TRUST_TIERS else DEFAULT_TRUST

--- a/contracts/trust.py
+++ b/contracts/trust.py
@@ -83,6 +83,11 @@ def cap_unverified(tier: str | None) -> str:
         # strict-decode guarantee and this helper's str return type intact.
         raise ValueError(f"trust must be a string, got {type(tier).__name__}")
     normalized = tier.strip().lower()
+    if normalized not in TRUST_TIERS:
+        # Unrecognized tier: return it as-is (normalized) rather than silently
+        # coercing to a default, so the caller's validate() rejects the malformed
+        # value instead of accepting a self-declared garbage tier.
+        return normalized
     if rank(normalized) > rank(UNVERIFIED_CEILING):
         return UNVERIFIED_CEILING
-    return normalized if normalized in TRUST_TIERS else DEFAULT_TRUST
+    return normalized

--- a/contracts/trust.py
+++ b/contracts/trust.py
@@ -24,15 +24,17 @@ TRUST_TIERS: tuple[str, ...] = (
 # Map each existing source_kind to its default trust tier. New transports register
 # their own tier explicitly when they emit events.
 SOURCE_KIND_TRUST: dict[str, str] = {
-    "rss": "known_feed",
     "news_api": "authenticated_api",
     "google_cse": "open_search",
     "bing_search": "open_search",
     "duckduckgo": "open_search",
-    # emergency_search resolves to open-web (DuckDuckGo) queries via
-    # utils.sources.search_emergency_info, so it is open_search — NOT a curated
-    # feed. Classifying it higher would let open-web content cross the trust
-    # boundary used for automation and prompt-injection defense (issue #70).
+    # The ingest pipeline tags *every* feed item — discovered local feeds, Google
+    # News RSS, Reddit RSS, as well as genuine agency feeds — with source_kind
+    # "rss"/"emergency_search". Since the bucket is mostly uncurated, both map to
+    # open_search so arbitrary feed/web content cannot cross the automation /
+    # prompt-injection trust boundary (issue #70). A dedicated higher-trust
+    # source kind for curated agency feeds (e.g. NWS CAP) can be added later.
+    "rss": "open_search",
     "emergency_search": "open_search",
 }
 

--- a/contracts/trust.py
+++ b/contracts/trust.py
@@ -40,6 +40,13 @@ SOURCE_KIND_TRUST: dict[str, str] = {
 
 DEFAULT_TRUST = "open_search"
 
+# The highest trust a payload may *self-declare* over an unauthenticated
+# transport. Tiers above this (known_feed and up — the automation-eligible band)
+# require verification the receiver does not yet have (authenticated transport or
+# a valid signature, Phase 4), so unverified inbound events are clamped here to
+# stop a peer from self-promoting across the automation boundary.
+UNVERIFIED_CEILING = "open_search"
+
 
 def rank(tier: str | None) -> int:
     """Return a comparable rank for a trust tier (higher = more trusted)."""
@@ -60,3 +67,17 @@ def is_trusted_for_automation(tier: str | None, *, minimum: str = "known_feed") 
     """Whether an event at ``tier`` is trusted enough to drive automated actions."""
 
     return rank(tier) >= rank(minimum)
+
+
+def cap_unverified(tier: str | None) -> str:
+    """Clamp a self-declared trust tier to :data:`UNVERIFIED_CEILING`.
+
+    Applied to events decoded from an unauthenticated transport so a sender
+    cannot self-declare ``authenticated_api``/``signed_node`` and have the
+    receiver act on it. Phase 4 signature verification will re-establish higher
+    trust for events that actually prove it.
+    """
+
+    if rank(tier) > rank(UNVERIFIED_CEILING):
+        return UNVERIFIED_CEILING
+    return tier if tier in TRUST_TIERS else DEFAULT_TRUST

--- a/contracts/trust.py
+++ b/contracts/trust.py
@@ -79,9 +79,9 @@ def cap_unverified(tier: str | None) -> str:
     """
 
     if not isinstance(tier, str):
-        # Non-string (e.g. JSON number/array): leave it unchanged so the caller's
-        # validate() rejects it with ValueError rather than crashing here.
-        return tier
+        # Non-string (e.g. a JSON number/array): a ValueError here keeps both the
+        # strict-decode guarantee and this helper's str return type intact.
+        raise ValueError(f"trust must be a string, got {type(tier).__name__}")
     normalized = tier.strip().lower()
     if rank(normalized) > rank(UNVERIFIED_CEILING):
         return UNVERIFIED_CEILING

--- a/contracts/trust.py
+++ b/contracts/trust.py
@@ -49,10 +49,15 @@ UNVERIFIED_CEILING = "open_search"
 
 
 def rank(tier: str | None) -> int:
-    """Return a comparable rank for a trust tier (higher = more trusted)."""
+    """Return a comparable rank for a trust tier (higher = more trusted).
 
+    Degrades to the default rank for unknown or non-string input (this helper is
+    called on decoded/untrusted data, so it must not raise)."""
+
+    if not isinstance(tier, str):
+        return TRUST_TIERS.index(DEFAULT_TRUST)
     try:
-        return TRUST_TIERS.index((tier or "").strip().lower())
+        return TRUST_TIERS.index(tier.strip().lower())
     except ValueError:
         return TRUST_TIERS.index(DEFAULT_TRUST)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Welcome to the VigilantCore documentation.
 | [Features](features.md) | Complete feature documentation |
 | [Source Discovery & Regional Coverage](source-discovery.md) | How outage/emergency/cross-region source selection works |
 | [Examples](examples.md) | Real-world usage examples |
+| [EmergencyEvent Schema](emergency-event-schema.md) | The canonical cross-node event contract (v2.0) |
 
 ## Quick Links
 

--- a/docs/emergency-event-schema.md
+++ b/docs/emergency-event-schema.md
@@ -53,7 +53,7 @@ prompts. `contracts.trust` maps legacy `source_kind`s to tiers and exposes
 {
   "schema_version": "2.0",
   "event_id": "01J9Z3R8K2QF7M4V0WXYABCDEF",
-  "origin_node_id": "01J9Z000NODE000000000HUB00",
+  "origin_node_id": "01J9Z000V8HKMNPQRSTVWXYZ23",
   "title": "Tornado Warning issued for Mercer County",
   "hazard_type": "tornado",
   "severity": "high",
@@ -69,7 +69,7 @@ prompts. `contracts.trust` maps legacy `source_kind`s to tiers and exposes
   "sources": ["NWS"],
   "trust": "known_feed",
   "ttl_hops": 4,
-  "seen_nodes": ["01J9Z000NODE000000000HUB00"],
+  "seen_nodes": ["01J9Z000V8HKMNPQRSTVWXYZ23"],
   "actions": [],
   "signature": null
 }

--- a/docs/emergency-event-schema.md
+++ b/docs/emergency-event-schema.md
@@ -33,8 +33,8 @@ trust. This schema is the basis for ShelfCast-compatible MQTT output (issue #60)
 | `url` | string \| null | no | Canonical source URL. |
 | `sources` | string[] | no | Provenance (merged source names). |
 | `trust` | enum | no | `untrusted` < `open_search` < `known_feed` < `authenticated_api` < `signed_node`. |
-| `ttl_hops` | integer ≥ 0 | no | Remaining mesh hops; decremented per forward. |
-| `seen_nodes` | string[] | no | Nodes that handled it (loop prevention). |
+| `ttl_hops` | integer ≥ 0 | yes | Remaining mesh hops; decremented per forward. |
+| `seen_nodes` | string[] | yes | Nodes that handled it (loop prevention). |
 | `actions` | object[] | no | Recommended/dispatched actions (`{kind, detail, status}`). |
 | `signature` | string \| null | no | Optional Ed25519 signature (Phase 4). |
 

--- a/docs/emergency-event-schema.md
+++ b/docs/emergency-event-schema.md
@@ -67,7 +67,7 @@ prompts. `contracts.trust` maps legacy `source_kind`s to tiers and exposes
   "predictive_outcome": "Damaging winds and possible touchdown within 30 minutes.",
   "url": "https://example.gov/alerts/123",
   "sources": ["NWS"],
-  "trust": "known_feed",
+  "trust": "open_search",
   "ttl_hops": 4,
   "seen_nodes": ["01J9Z000V8HKMNPQRSTVWXYZ23"],
   "actions": [],

--- a/docs/emergency-event-schema.md
+++ b/docs/emergency-event-schema.md
@@ -1,0 +1,103 @@
+# EmergencyEvent Schema (v2.0)
+
+`EmergencyEvent` is the canonical, versioned contract every platform component
+exchanges — the ingest pipeline, the dashboard, the MQTT bus, sibling apps, and
+the Rust/Go edge daemons. It is defined in `contracts/` with:
+
+- `contracts/emergency_event.schema.json` — the JSON Schema (draft 2020-12).
+- `contracts/event.py` — the `EmergencyEvent` dataclass, validator, and the
+  `from_normalized()` adapter.
+
+It is a **strict superset of the v1.0 normalized alert** (see
+[event-normalization.md](event-normalization.md)), so existing alerts upgrade
+without data loss while new fields enable cross-node propagation, routing, and
+trust. This schema is the basis for ShelfCast-compatible MQTT output (issue #60).
+
+## Fields
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `schema_version` | string (`"2.0"`) | yes | Contract version. |
+| `event_id` | string (ULID) | yes | Stable id for cross-node dedup. |
+| `origin_node_id` | string \| null | no | Node that first observed/produced it. |
+| `title` | string | yes | Headline. |
+| `hazard_type` | enum | yes | `storm`, `hurricane`, `tornado`, `fire`, `flood`, `earthquake`, `outage`, `hazmat`, `conflict`, `transport`, `medical`, `other`. |
+| `severity` | enum | yes | `low`, `medium`, `high`, `critical`. |
+| `confidence` | number 0–1 | yes | Source/relevance-derived confidence. |
+| `impact_score` | integer 1–10 | yes | Impact magnitude. |
+| `timestamp_utc` | string (ISO-8601) | yes | When the record was observed/created. |
+| `event_timestamp_utc` | string \| null | no | When the hazard occurred. |
+| `location` | object | no | `{name, zip_code, latitude, longitude, radius_km, geohash}`. |
+| `summary` | string | no | Short description. |
+| `predictive_outcome` | string | no | AI/heuristic prediction of what happens next. |
+| `url` | string \| null | no | Canonical source URL. |
+| `sources` | string[] | no | Provenance (merged source names). |
+| `trust` | enum | no | `untrusted` < `open_search` < `known_feed` < `authenticated_api` < `signed_node`. |
+| `ttl_hops` | integer ≥ 0 | no | Remaining mesh hops; decremented per forward. |
+| `seen_nodes` | string[] | no | Nodes that handled it (loop prevention). |
+| `actions` | object[] | no | Recommended/dispatched actions (`{kind, detail, status}`). |
+| `signature` | string \| null | no | Optional Ed25519 signature (Phase 4). |
+
+## Trust tiers
+
+`trust` is the boundary the AI/RAG pipeline (issue #70) and the routing engine
+consult. Higher-trust events may be acted on automatically and are preferred when
+channels are contended; lower-trust content (open web search, unauthenticated
+mesh) is treated as untrusted input and must never inject instructions into LLM
+prompts. `contracts.trust` maps legacy `source_kind`s to tiers and exposes
+`rank()` / `is_trusted_for_automation()`.
+
+## Example
+
+```json
+{
+  "schema_version": "2.0",
+  "event_id": "01J9Z3R8K2QF7M4V0WXYABCDEF",
+  "origin_node_id": "01J9Z000NODE000000000HUB00",
+  "title": "Tornado Warning issued for Mercer County",
+  "hazard_type": "tornado",
+  "severity": "high",
+  "confidence": 0.86,
+  "impact_score": 8,
+  "timestamp_utc": "2026-06-19T18:00:00Z",
+  "event_timestamp_utc": "2026-06-19T17:58:00Z",
+  "location": {"name": "Mercer County, NJ", "zip_code": "08540",
+               "latitude": 40.34, "longitude": -74.65, "geohash": "dr4vmr9"},
+  "summary": "Take shelter now; storm capable of producing a tornado.",
+  "predictive_outcome": "Damaging winds and possible touchdown within 30 minutes.",
+  "url": "https://example.gov/alerts/123",
+  "sources": ["NWS"],
+  "trust": "known_feed",
+  "ttl_hops": 4,
+  "seen_nodes": ["01J9Z000NODE000000000HUB00"],
+  "actions": [],
+  "signature": null
+}
+```
+
+## Usage
+
+```python
+from contracts import EmergencyEvent
+
+# Build from the existing normalization output (ingest path):
+event = EmergencyEvent.from_normalized(normalized=normalized_payload,
+                                       title=title, snippet=snippet,
+                                       impact_score=8, source="NWS",
+                                       source_kind="rss")
+event.validate()          # raises on contract violation (uses jsonschema if present)
+payload = event.to_json()  # for MQTT/transports
+
+# Parse on the receiving side (transport / edge daemon):
+received = EmergencyEvent.from_json(payload)
+```
+
+## MQTT topics
+
+The MQTT transport (`plugins/builtin/mqtt_transport.py`) publishes schema-valid
+events to:
+
+- `intel/events/normalized` — every event (issue #57).
+- `intel/events/high_priority` — `high`/`critical` events (issue #58).
+
+Base topic is configurable via the plugin's `base_topic` option.

--- a/docs/emergency-event-schema.md
+++ b/docs/emergency-event-schema.md
@@ -94,10 +94,11 @@ received = EmergencyEvent.from_json(payload)
 
 ## MQTT topics
 
-The MQTT transport (`plugins/builtin/mqtt_transport.py`) publishes schema-valid
-events to:
+A later release adds an MQTT transport plugin that publishes schema-valid events
+to:
 
 - `intel/events/normalized` — every event (issue #57).
 - `intel/events/high_priority` — `high`/`critical` events (issue #58).
 
-Base topic is configurable via the plugin's `base_topic` option.
+The base topic will be configurable via the plugin's `base_topic` option. This
+contract defines the payload shape those topics carry.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pgeocode
 flask
 beautifulsoup4
 psutil
+jsonschema

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -37,5 +37,6 @@ print_info "Building VigilantCore executable (PyInstaller)."
 cd "$ROOT_DIR"
 python -m pip install --upgrade pip
 pip install -r requirements.txt
-pyinstaller --onefile --windowed src/main.py --name VigilantCore
+pyinstaller --onefile --windowed src/main.py --name VigilantCore \
+  --add-data "contracts/emergency_event.schema.json:contracts"
 print_success "Build complete. See dist/VigilantCore"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -37,6 +37,12 @@ print_info "Building VigilantCore executable (PyInstaller)."
 cd "$ROOT_DIR"
 python -m pip install --upgrade pip
 pip install -r requirements.txt
+# PyInstaller --add-data uses a platform-dependent separator: ';' on Windows
+# (incl. Git Bash), ':' elsewhere.
+case "${OSTYPE:-}" in
+  msys*|cygwin*|win32*) DATA_SEP=";" ;;
+  *) DATA_SEP=":" ;;
+esac
 pyinstaller --onefile --windowed src/main.py --name VigilantCore \
-  --add-data "contracts/emergency_event.schema.json:contracts"
+  --add-data "contracts/emergency_event.schema.json${DATA_SEP}contracts"
 print_success "Build complete. See dist/VigilantCore"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -36,7 +36,7 @@ fi
 print_info "Running smoke import check."
 cd "$ROOT_DIR"
 python -m pip install -r requirements.txt
-python -c "import engine.monitor, engine.parser, utils.database, utils.config, utils.sources, utils.geo, src.web_app; print('smoke ok')"
-print_info "Running platform compatibility unit tests."
-python -m unittest discover -s tests -p "test_platform_compat.py" -v
+python -c "import engine.monitor, engine.parser, utils.database, utils.config, utils.sources, utils.geo, src.web_app, contracts; print('smoke ok')"
+print_info "Running unit tests."
+python -m unittest discover -s tests -p "test_*.py" -v
 print_success "Smoke check complete."

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import unittest
 
 from contracts import EmergencyEvent, infer_hazard_type, new_ulid, trust
@@ -44,7 +45,9 @@ class EmergencyEventContractTests(unittest.TestCase):
         # New platform fields derived.
         self.assertEqual(event.schema_version, "2.0")
         self.assertEqual(event.hazard_type, "tornado")
-        self.assertEqual(event.trust, "known_feed")
+        # Generic RSS is uncurated (discovered feeds, Google News, Reddit), so it
+        # is open_search — not trusted for automation.
+        self.assertEqual(event.trust, "open_search")
         self.assertTrue(event.event_id)
         # Geohash enrichment from coordinates.
         self.assertEqual(event.location["geohash"], encode(40.34, -74.65))
@@ -108,6 +111,38 @@ class EmergencyEventContractTests(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             event.validate()
+
+    def test_validate_enforces_ulid_and_iso_utc_formats(self) -> None:
+        base = EmergencyEvent(title="t", severity="low", confidence=0.5, impact_score=5)
+        base.validate()  # a freshly-minted event has a valid ULID + UTC timestamp
+        # Non-ULID id.
+        bad_id = EmergencyEvent(title="t", severity="low", confidence=0.5,
+                                impact_score=5, event_id="not-a-ulid")
+        with self.assertRaises(ValueError):
+            bad_id.validate()
+        # Non-ISO / non-UTC timestamp.
+        bad_ts = EmergencyEvent(title="t", severity="low", confidence=0.5,
+                                impact_score=5, timestamp_utc="last tuesday")
+        with self.assertRaises(ValueError):
+            bad_ts.validate()
+        # event_timestamp_utc, when present, must also be ISO UTC.
+        bad_ets = EmergencyEvent(title="t", severity="low", confidence=0.5,
+                                 impact_score=5, event_timestamp_utc="nope")
+        with self.assertRaises(ValueError):
+            bad_ets.validate()
+
+    def test_strict_decode_requires_mesh_fields(self) -> None:
+        # A payload omitting ttl_hops/seen_nodes must be rejected, else a
+        # forwarded (possibly TTL-exhausted/looping) event is re-admitted as fresh.
+        full = EmergencyEvent(title="t", severity="high", confidence=0.5, impact_score=6)
+        payload = json.loads(full.to_json())
+        for missing in ("ttl_hops", "seen_nodes"):
+            partial = dict(payload)
+            partial.pop(missing)
+            with self.assertRaises(ValueError):
+                EmergencyEvent.from_dict(partial, strict=True)
+        # The complete payload still decodes.
+        EmergencyEvent.from_dict(payload, strict=True)
 
     def test_from_dict_ignores_unknown_fields(self) -> None:
         event = EmergencyEvent.from_dict(

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -99,6 +99,16 @@ class EmergencyEventContractTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             bad.validate()
 
+    def test_validate_rejects_numeric_strings_without_jsonschema(self) -> None:
+        # A payload with ttl_hops="1" must be rejected by validate(), otherwise
+        # can_forward() ("1" > 0) raises TypeError on dependency-free nodes.
+        event = EmergencyEvent.from_dict(
+            {"title": "t", "severity": "low", "confidence": 0.5,
+             "impact_score": 5, "ttl_hops": "1"}
+        )
+        with self.assertRaises(ValueError):
+            event.validate()
+
     def test_from_dict_ignores_unknown_fields(self) -> None:
         event = EmergencyEvent.from_dict(
             {"title": "t", "hazard_type": "fire", "totally_unknown": 1}

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -226,6 +226,25 @@ class EmergencyEventContractTests(unittest.TestCase):
         self.assertTrue(trust.is_trusted_for_automation("authenticated_api"))
         self.assertFalse(trust.is_trusted_for_automation("open_search"))
 
+    def test_cap_unverified_normalizes_case_and_whitespace(self) -> None:
+        # Differently-cased/spaced tiers must normalize, not silently jump to the
+        # default (which could even upgrade "UNTRUSTED" -> open_search).
+        self.assertEqual(trust.cap_unverified("SIGNED_NODE"), "open_search")
+        self.assertEqual(trust.cap_unverified(" untrusted "), "untrusted")
+        self.assertEqual(trust.cap_unverified("OPEN_SEARCH"), "open_search")
+
+    def test_from_normalized_tolerates_bad_impact_score(self) -> None:
+        event = EmergencyEvent.from_normalized(
+            normalized=self._normalized(), title="x", impact_score="not-a-number"
+        )
+        self.assertEqual(event.impact_score, 1)
+
+    def test_ulid_regex_excludes_crockford_gaps(self) -> None:
+        from contracts.event import _looks_like_ulid
+        self.assertTrue(_looks_like_ulid(new_ulid()))
+        for ch in ("I", "L", "O", "U"):
+            self.assertFalse(_looks_like_ulid(ch * 26))
+
     def test_strict_decode_caps_self_declared_trust(self) -> None:
         # An unauthenticated peer must not promote itself across the automation
         # boundary by self-declaring a high trust tier on the wire.

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -144,6 +144,22 @@ class EmergencyEventContractTests(unittest.TestCase):
         # The complete payload still decodes.
         EmergencyEvent.from_dict(payload, strict=True)
 
+    def test_strict_decode_rejects_present_but_malformed_values(self) -> None:
+        # All required keys present, but malformed values must be rejected on
+        # decode (not just on a later validate()), so transports never hand back
+        # an event that would TypeError in can_forward().
+        full = EmergencyEvent(title="t", severity="high", confidence=0.5, impact_score=6)
+        payload = json.loads(full.to_json())
+        for field_name, bad in (
+            ("ttl_hops", "1"),
+            ("event_id", "not-a-ulid"),
+            ("timestamp_utc", "whenever"),
+            ("seen_nodes", "nodeA"),
+        ):
+            broken = dict(payload, **{field_name: bad})
+            with self.assertRaises(ValueError):
+                EmergencyEvent.from_json(json.dumps(broken))
+
     def test_from_dict_ignores_unknown_fields(self) -> None:
         event = EmergencyEvent.from_dict(
             {"title": "t", "hazard_type": "fire", "totally_unknown": 1}

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -233,6 +233,36 @@ class EmergencyEventContractTests(unittest.TestCase):
         self.assertEqual(trust.cap_unverified(" untrusted "), "untrusted")
         self.assertEqual(trust.cap_unverified("OPEN_SEARCH"), "open_search")
 
+    def test_iso_utc_structural_check_matches_schema(self) -> None:
+        # A space separator parses via fromisoformat but is not canonical; the
+        # structural check must reject it just like the schema does.
+        bad = EmergencyEvent(title="t", severity="low", confidence=0.5,
+                             impact_score=5, timestamp_utc="2026-06-19 18:00:00Z")
+        with self.assertRaises(ValueError):
+            bad.validate()
+
+    def test_from_normalized_treats_string_merged_sources_as_scalar(self) -> None:
+        event = EmergencyEvent.from_normalized(
+            normalized=self._normalized(), title="x", source="NWS",
+            merged_sources="County OEM",
+        )
+        self.assertIn("County OEM", event.sources)
+        self.assertNotIn("C", event.sources)  # not iterated char-by-char
+
+    def test_strict_decode_rejects_falsy_nonstring_title(self) -> None:
+        full = EmergencyEvent(title="t", severity="high", confidence=0.5, impact_score=6)
+        payload = json.loads(full.to_json())
+        for bad_title in (0, False, []):
+            with self.assertRaises(ValueError):
+                EmergencyEvent.from_json(json.dumps(dict(payload, title=bad_title)))
+
+    def test_strict_decode_rejects_nonstring_trust_with_value_error(self) -> None:
+        full = EmergencyEvent(title="t", severity="high", confidence=0.5, impact_score=6)
+        payload = json.loads(full.to_json())
+        for bad_trust in (123, ["signed_node"]):
+            with self.assertRaises(ValueError):
+                EmergencyEvent.from_json(json.dumps(dict(payload, trust=bad_trust)))
+
     def test_from_normalized_tolerates_bad_impact_score(self) -> None:
         event = EmergencyEvent.from_normalized(
             normalized=self._normalized(), title="x", impact_score="not-a-number"

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -83,6 +83,21 @@ class EmergencyEventContractTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             EmergencyEvent.from_json(json.dumps(dict(payload, trust="totally_bogus")))
 
+    def test_validate_rejects_nonstring_optional_fields(self) -> None:
+        for field_name, bad in (
+            ("summary", 5), ("predictive_outcome", []),
+            ("origin_node_id", 7), ("url", {}), ("signature", 1),
+        ):
+            event = EmergencyEvent(title="t", severity="low", confidence=0.5,
+                                   impact_score=5)
+            setattr(event, field_name, bad)
+            with self.assertRaises(ValueError):
+                event.validate()
+
+    def test_lenient_from_dict_preserves_nonstring_title(self) -> None:
+        # 0 is preserved (not masked), so a later validate() can reject it.
+        self.assertEqual(EmergencyEvent.from_dict({"title": 0}).title, 0)
+
     def test_validate_rejects_wrong_item_types_in_collections(self) -> None:
         for field_name, bad in (
             ("sources", [123]),

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -70,6 +70,19 @@ class EmergencyEventContractTests(unittest.TestCase):
         )
         event.validate()  # should not raise
 
+    def test_validate_rejects_truthy_nonstring_title(self) -> None:
+        for bad in (123, b"x", ["x"]):
+            event = EmergencyEvent(title=bad, severity="low", confidence=0.5,
+                                   impact_score=5)
+            with self.assertRaises(ValueError):
+                event.validate()
+
+    def test_strict_decode_rejects_unrecognized_trust_tier(self) -> None:
+        full = EmergencyEvent(title="t", severity="high", confidence=0.5, impact_score=6)
+        payload = json.loads(full.to_json())
+        with self.assertRaises(ValueError):
+            EmergencyEvent.from_json(json.dumps(dict(payload, trust="totally_bogus")))
+
     def test_validate_rejects_wrong_item_types_in_collections(self) -> None:
         for field_name, bad in (
             ("sources", [123]),

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import unittest
+
+from contracts import EmergencyEvent, infer_hazard_type, new_ulid, trust
+from contracts.geohash import encode
+from utils.event_normalization import normalize_event_payload
+
+
+class EmergencyEventContractTests(unittest.TestCase):
+    def _normalized(self) -> dict:
+        return normalize_event_payload(
+            source_event={"published_at": "2026-06-19T17:58:00Z", "source": "NWS"},
+            impact_score=8,
+            is_relevant=True,
+            location_name="Mercer County, NJ",
+            source_kind="rss",
+            zip_code="08540",
+            latitude=40.34,
+            longitude=-74.65,
+        )
+
+    def test_from_normalized_upgrades_losslessly(self) -> None:
+        normalized = self._normalized()
+        event = EmergencyEvent.from_normalized(
+            normalized=normalized,
+            title="Tornado Warning issued for Mercer County",
+            snippet="Take shelter now.",
+            impact_score=8,
+            predictive_outcome="Touchdown possible within 30 minutes.",
+            url="https://example.gov/alerts/123",
+            source="NWS",
+            source_kind="rss",
+        )
+        # v1.0 fields preserved.
+        self.assertEqual(event.severity, normalized["severity"])
+        self.assertEqual(event.confidence, normalized["confidence"])
+        self.assertEqual(event.event_timestamp_utc, normalized["timestamp_utc"])
+        self.assertEqual(event.location["zip_code"], "08540")
+        # New platform fields derived.
+        self.assertEqual(event.schema_version, "2.0")
+        self.assertEqual(event.hazard_type, "tornado")
+        self.assertEqual(event.trust, "known_feed")
+        self.assertTrue(event.event_id)
+        # Geohash enrichment from coordinates.
+        self.assertEqual(event.location["geohash"], encode(40.34, -74.65))
+
+    def test_json_round_trip(self) -> None:
+        event = EmergencyEvent.from_normalized(
+            normalized=self._normalized(),
+            title="Flooding near the river",
+            snippet="Water rising",
+            impact_score=6,
+            source="County OEM",
+            source_kind="emergency_search",
+        )
+        restored = EmergencyEvent.from_json(event.to_json())
+        self.assertEqual(restored.to_dict(), event.to_dict())
+
+    def test_validate_passes_for_valid_event_and_uses_schema(self) -> None:
+        event = EmergencyEvent.from_normalized(
+            normalized=self._normalized(), title="Storm", impact_score=4
+        )
+        event.validate()  # should not raise
+
+    def test_validate_rejects_bad_values(self) -> None:
+        event = EmergencyEvent(title="x", hazard_type="not-a-hazard")
+        with self.assertRaises(ValueError):
+            event.validate()
+        event2 = EmergencyEvent(title="x", confidence=5.0)
+        with self.assertRaises(ValueError):
+            event2.validate()
+
+    def test_from_dict_ignores_unknown_fields(self) -> None:
+        event = EmergencyEvent.from_dict(
+            {"title": "t", "hazard_type": "fire", "totally_unknown": 1}
+        )
+        self.assertEqual(event.hazard_type, "fire")
+
+    def test_hazard_inference(self) -> None:
+        self.assertEqual(infer_hazard_type("Wildfire near town"), "fire")
+        self.assertEqual(infer_hazard_type("Category 4 hurricane"), "hurricane")
+        self.assertEqual(infer_hazard_type("Power outage hits grid"), "outage")
+        self.assertEqual(infer_hazard_type("Nothing notable"), "other")
+
+    def test_mesh_helpers(self) -> None:
+        event = EmergencyEvent(title="t", ttl_hops=2)
+        self.assertTrue(event.can_forward("A"))
+        event.mark_seen("A")
+        event.mark_seen("A")  # idempotent
+        self.assertEqual(event.seen_nodes, ["A"])
+        self.assertFalse(event.can_forward("A"))  # looped
+        forwarded = event.decremented()
+        self.assertEqual(forwarded.ttl_hops, 1)
+        self.assertEqual(event.ttl_hops, 2)  # original untouched
+
+    def test_ttl_zero_cannot_forward(self) -> None:
+        event = EmergencyEvent(title="t", ttl_hops=0)
+        self.assertFalse(event.can_forward("B"))
+
+    def test_trust_ordering(self) -> None:
+        self.assertGreater(trust.rank("signed_node"), trust.rank("open_search"))
+        self.assertTrue(trust.is_trusted_for_automation("authenticated_api"))
+        self.assertFalse(trust.is_trusted_for_automation("open_search"))
+
+    def test_ulid_is_sortable_and_sized(self) -> None:
+        a = new_ulid(timestamp_ms=1000)
+        b = new_ulid(timestamp_ms=2000)
+        self.assertEqual(len(a), 26)
+        self.assertLess(a, b)  # time-ordered
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -105,6 +105,34 @@ class EmergencyEventContractTests(unittest.TestCase):
         )
         self.assertEqual(event.hazard_type, "fire")
 
+    def test_from_json_rejects_incomplete_payload(self) -> None:
+        # Decoding a transport payload must NOT mint a missing event_id/timestamp;
+        # an incomplete payload is rejected so receivers don't assign new
+        # identities and corrupt cross-node dedup.
+        with self.assertRaises(ValueError):
+            EmergencyEvent.from_json("{}")
+        with self.assertRaises(ValueError):
+            EmergencyEvent.from_json("not json")
+        # A complete payload round-trips fine under strict decode.
+        full = EmergencyEvent(title="t", hazard_type="fire", severity="high",
+                              confidence=0.5, impact_score=6)
+        self.assertEqual(EmergencyEvent.from_json(full.to_json()).event_id, full.event_id)
+
+    def test_from_dict_lenient_for_local_construction(self) -> None:
+        # Local construction (strict=False, the default) still mints an id.
+        event = EmergencyEvent.from_dict({"title": "t"})
+        self.assertTrue(event.event_id)
+
+    def test_validate_rejects_malformed_structured_fields(self) -> None:
+        event = EmergencyEvent(title="t", severity="low", confidence=0.5, impact_score=5)
+        event.seen_nodes = "nodeA"  # should be a list
+        with self.assertRaises(ValueError):
+            event.validate()
+        event2 = EmergencyEvent(title="t", severity="low", confidence=0.5, impact_score=5)
+        event2.location = "somewhere"  # should be an object
+        with self.assertRaises(ValueError):
+            event2.validate()
+
     def test_hazard_inference(self) -> None:
         self.assertEqual(infer_hazard_type("Wildfire near town"), "fire")
         self.assertEqual(infer_hazard_type("Category 4 hurricane"), "hurricane")

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -64,11 +64,23 @@ class EmergencyEventContractTests(unittest.TestCase):
         restored = EmergencyEvent.from_json(event.to_json())
         self.assertEqual(restored.to_dict(), event.to_dict())
 
-    def test_validate_passes_for_valid_event_and_uses_schema(self) -> None:
+    def test_validate_passes_for_valid_event(self) -> None:
         event = EmergencyEvent.from_normalized(
             normalized=self._normalized(), title="Storm", impact_score=4
         )
         event.validate()  # should not raise
+
+    def test_validate_rejects_wrong_item_types_in_collections(self) -> None:
+        for field_name, bad in (
+            ("sources", [123]),
+            ("seen_nodes", [{"x": 1}]),
+            ("actions", ["not-an-object"]),
+        ):
+            event = EmergencyEvent(title="t", severity="low", confidence=0.5,
+                                   impact_score=5)
+            setattr(event, field_name, bad)
+            with self.assertRaises(ValueError):
+                event.validate()
 
     def test_validate_rejects_bad_values(self) -> None:
         event = EmergencyEvent(title="x", hazard_type="not-a-hazard")

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -35,7 +35,11 @@ class EmergencyEventContractTests(unittest.TestCase):
         # v1.0 fields preserved.
         self.assertEqual(event.severity, normalized["severity"])
         self.assertEqual(event.confidence, normalized["confidence"])
-        self.assertEqual(event.event_timestamp_utc, normalized["timestamp_utc"])
+        # The v1 timestamp_utc (published/observed time) is preserved verbatim in
+        # timestamp_utc; event_timestamp_utc stays unset (no hazard-occurrence
+        # time in the normalized payload).
+        self.assertEqual(event.timestamp_utc, normalized["timestamp_utc"])
+        self.assertIsNone(event.event_timestamp_utc)
         self.assertEqual(event.location["zip_code"], "08540")
         # New platform fields derived.
         self.assertEqual(event.schema_version, "2.0")
@@ -71,6 +75,30 @@ class EmergencyEventContractTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             event2.validate()
 
+    def test_validate_enforces_core_invariants_without_jsonschema(self) -> None:
+        """Structural checks must catch schema-required invariants even when the
+        jsonschema deep check is unavailable/unbundled."""
+
+        # Wrong schema version (e.g. a stale v1 payload).
+        with self.assertRaises(ValueError):
+            EmergencyEvent(title="x", schema_version="1.0").validate()
+        # Empty event_id breaks cross-node dedup.
+        with self.assertRaises(ValueError):
+            EmergencyEvent(title="x", event_id="").validate()
+        # Empty timestamp_utc.
+        with self.assertRaises(ValueError):
+            EmergencyEvent(title="x", timestamp_utc="").validate()
+
+    def test_validate_raises_value_error_not_type_error_on_malformed_input(self) -> None:
+        """Parsing untrusted JSON can yield None/str numerics; validate() must
+        surface ValueError, never TypeError."""
+
+        bad = EmergencyEvent.from_dict(
+            {"title": "t", "confidence": None, "impact_score": "oops"}
+        )
+        with self.assertRaises(ValueError):
+            bad.validate()
+
     def test_from_dict_ignores_unknown_fields(self) -> None:
         event = EmergencyEvent.from_dict(
             {"title": "t", "hazard_type": "fire", "totally_unknown": 1}
@@ -102,6 +130,16 @@ class EmergencyEventContractTests(unittest.TestCase):
         self.assertGreater(trust.rank("signed_node"), trust.rank("open_search"))
         self.assertTrue(trust.is_trusted_for_automation("authenticated_api"))
         self.assertFalse(trust.is_trusted_for_automation("open_search"))
+
+    def test_emergency_search_is_open_search_not_curated(self) -> None:
+        # emergency_search runs open-web queries, so it must not be trusted for
+        # automation as if it were a curated feed (issue #70 boundary).
+        self.assertEqual(trust.for_source_kind("emergency_search"), "open_search")
+        self.assertFalse(trust.is_trusted_for_automation("open_search"))
+        event = EmergencyEvent.from_normalized(
+            normalized=self._normalized(), title="x", source_kind="emergency_search"
+        )
+        self.assertEqual(event.trust, "open_search")
 
     def test_ulid_is_sortable_and_sized(self) -> None:
         a = new_ulid(timestamp_ms=1000)

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -184,6 +184,12 @@ class EmergencyEventContractTests(unittest.TestCase):
         event = EmergencyEvent.from_dict({"title": "t"})
         self.assertTrue(event.event_id)
 
+    def test_from_dict_defaults_empty_or_null_title(self) -> None:
+        # A present-but-null/empty title is defaulted, not left as None.
+        self.assertEqual(EmergencyEvent.from_dict({"title": None}).title, "(no title)")
+        self.assertEqual(EmergencyEvent.from_dict({"title": ""}).title, "(no title)")
+        self.assertEqual(EmergencyEvent.from_dict({}).title, "(no title)")
+
     def test_validate_rejects_malformed_structured_fields(self) -> None:
         event = EmergencyEvent(title="t", severity="low", confidence=0.5, impact_score=5)
         event.seen_nodes = "nodeA"  # should be a list

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -220,6 +220,18 @@ class EmergencyEventContractTests(unittest.TestCase):
         self.assertTrue(trust.is_trusted_for_automation("authenticated_api"))
         self.assertFalse(trust.is_trusted_for_automation("open_search"))
 
+    def test_strict_decode_caps_self_declared_trust(self) -> None:
+        # An unauthenticated peer must not promote itself across the automation
+        # boundary by self-declaring a high trust tier on the wire.
+        event = EmergencyEvent(title="t", severity="high", confidence=0.5,
+                               impact_score=6, trust="signed_node")
+        decoded = EmergencyEvent.from_json(event.to_json())
+        self.assertEqual(decoded.trust, "open_search")
+        self.assertFalse(trust.is_trusted_for_automation(decoded.trust))
+        # Lenient (local) construction keeps the declared tier.
+        local = EmergencyEvent.from_dict(event.to_dict())  # strict=False
+        self.assertEqual(local.trust, "signed_node")
+
     def test_emergency_search_is_open_search_not_curated(self) -> None:
         # emergency_search runs open-web queries, so it must not be trusted for
         # automation as if it were a curated feed (issue #70 boundary).


### PR DESCRIPTION
**Phase 1 platform series — PR 1 of 4** · base: `main`

Introduces the canonical, versioned (**v2.0**) `EmergencyEvent` contract every platform component will share (ingest pipeline, dashboard, MQTT bus, future Rust/Go edge daemons). It is a strict superset of the existing v1.0 normalized alert, so current alerts upgrade losslessly via `from_normalized()`.

### Adds
- `contracts/` — `EmergencyEvent` dataclass + `from_normalized()` adapter; new fields: stable `event_id` (ULID), `origin_node_id`, `hazard_type`, `trust` tier, mesh `ttl_hops`/`seen_nodes`, `actions`.
- `contracts/emergency_event.schema.json` — JSON Schema + validator (uses `jsonschema` when present, always applies structural checks so dependency-free edge nodes validate too).
- Dependency-free **ULID** (time-sortable ids) and **geohash** helpers; **trust tiers** (`contracts/trust.py`) for the #70 injection boundary and routing priority.
- `tests/test_contract.py`; `jsonschema` dep; `docs/emergency-event-schema.md`.

### Testing
87 tests pass; ruff clean. No behaviour change — pure new package.

Stacked series: **0.10.0 (this)** → 0.11.0 plugins → 0.12.0 mesh → 0.13.0 engine integration. Lays the schema groundwork for #57/#58/#59/#60.