### PR TITLE
feat(plugins): plugin kernel + event bus + reference plugins (0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to VigilantCore will be documented in this file.
 
+## [0.11.0] - 2026-06-19
+
+### Added
+
+- **Plugin kernel** (`plugins/`): turns every capability into a composable plugin of one of four kinds — `SourcePlugin`, `TransportPlugin`, `DevicePlugin`, `SinkPlugin` — all speaking the `EmergencyEvent` contract and reporting health in the uniform v0.8.0 source-health shape.
+  - In-process **`EventBus`** (publish/subscribe) that supersedes the engine's single `on_new_alert` callback, with topics for new events, high-severity events, and inbound transport events.
+  - **Registry + config-driven loader** (`plugins/registry.py`, `plugins/loader.py`): declare plugins in config as `{type, name, enabled, options}`; `type` resolves to a built-in or a `module:ClassName` path. The registry stays fully inert when no plugins are configured.
+  - **Reference plugins**: an RSS source (proves the ingest seam), an MQTT transport publishing schema-valid events to `intel/events/normalized` and `intel/events/high_priority`, and a notification device.
+- **Tests** (`tests/test_plugin_registry.py`) covering bus delivery/isolation, severity-gated routing, source polling, the config loader, and MQTT validation.
+- Adds `paho-mqtt` to requirements; documents the kernel in `docs/architecture.md`.
+
 ## [0.10.0] - 2026-06-19
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Welcome to the VigilantCore documentation.
 | [Features](features.md) | Complete feature documentation |
 | [Source Discovery & Regional Coverage](source-discovery.md) | How outage/emergency/cross-region source selection works |
 | [Examples](examples.md) | Real-world usage examples |
+| [Platform Architecture](architecture.md) | Plugin kernel, event bus, and mesh node model |
 | [EmergencyEvent Schema](emergency-event-schema.md) | The canonical cross-node event contract (v2.0) |
 
 ## Quick Links

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,131 @@
+# VigilantCore Platform Architecture
+
+VigilantCore is evolving from a single-node event monitor into the coordinating
+**centerpiece for emergency action** — a system that monitors adverse events,
+reacts with or without internet and grid power, communicates over whatever links
+are available (LoRa/Meshtastic mesh, satellite, BLE, MQTT/LAN), informs other
+systems and responders, and uses local AI to fuse and prioritize.
+
+This document describes the **plugin kernel** that makes that possible. It was
+introduced in Phase 1 (architecture & contracts) and is the foundation every
+later capability builds on. It is fully backward compatible: with no plugins
+configured, VigilantCore behaves exactly as before.
+
+## The big picture
+
+```
+                         vigilant-core (Python hub)
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  INGEST            FUSION / AI            ROUTING            EGRESS     │
+  │  source plugins →  normalize → dedup  →   policy engine  →  transport  │
+  │  (RSS, APIs,       → impact (Ollama)  →   (urgency, geo,    + device   │
+  │   LoRa-in,           → AI fusion         channel, power)     plugins   │
+  │   sensors,         EmergencyEvent      MultiChannelRouter   (LoRa-out, │
+  │   MQTT-in)         (canonical, v2.0)   (Phase 2)            BLE, sat,   │
+  │                          │                                  MQTT, UI,  │
+  │                    SQLite store +                           siren)     │
+  │                    store-and-forward (mesh)                            │
+  └────────────┬─────────────────────────────────────────────┬───────────┘
+               │ shared EmergencyEvent contract (JSON)        │
+        ┌──────┴───────┐                              ┌────────┴────────┐
+        │ edge/ daemons │ (Rust/Go, low-power)        │ sibling apps    │
+        │ lora, mesh,   │  bridged via MQTT/stdio      │ via MQTT bus    │
+        │ satellite,    │                              │                 │
+        │ ble, power    │                              │                 │
+        └───────────────┘                              └─────────────────┘
+```
+
+## Components
+
+### The contract — `contracts/`
+
+`contracts.EmergencyEvent` is the single shape every component agrees on. It is a
+strict superset of the v1.0 normalized alert produced by
+`utils.event_normalization.normalize_event_payload`, so existing alerts upgrade
+losslessly (`EmergencyEvent.from_normalized`). New platform fields — a stable
+`event_id` (ULID), `origin_node_id`, `hazard_type`, `trust` tier, mesh
+`ttl_hops`/`seen_nodes`, and recommended `actions` — enable cross-node
+propagation, routing, and trust decisions. See
+[emergency-event-schema.md](emergency-event-schema.md).
+
+The contract is the boundary that lets the Rust/Go edge daemons (Phase 2) and
+sibling apps interoperate without sharing Python code: they exchange
+schema-valid JSON over MQTT/stdio.
+
+### The plugin kernel — `plugins/`
+
+Every capability is a plugin of one of four kinds (`plugins/base.py`):
+
+| Kind | Base class | Contract method | Examples |
+|------|-----------|-----------------|----------|
+| Source | `SourcePlugin` | `async poll(ctx) -> [EmergencyEvent]` | RSS, sensors, LoRa-in, MQTT-in |
+| Transport | `TransportPlugin` | `send(event)` (+ inbound to bus) | MQTT, LoRa/Meshtastic, BLE, satellite |
+| Device | `DevicePlugin` | `render(event)` | siren, display, GPIO relay, notification |
+| Sink | `SinkPlugin` | `handle(event)` | webhook, shell action, digest, export |
+
+Plugins communicate through an in-process **`EventBus`** (publish/subscribe),
+which replaces the engine's single `on_new_alert` callback. Topics:
+
+- `event.new` — every newly stored alert (transports + sinks subscribe).
+- `event.high` — high/critical only (devices like sirens default to this).
+- `event.ingest` — inbound events from transports re-entering the pipeline.
+
+Every plugin reports health in the same shape as the v0.8.0 source-health
+telemetry (`PluginHealth`: attempts, successes, errors, latency), so the
+dashboard can show all of them uniformly.
+
+### Lifecycle — `plugins/loader.py` + `plugins/registry.py`
+
+Plugins are declared in config (`AppConfig.plugins`) and loaded by `build_registry`:
+
+```json
+{
+  "plugins": [
+    {"type": "rss_source", "name": "county-rss", "enabled": true,
+     "options": {"feeds": ["https://example.gov/alerts.rss"]}},
+    {"type": "mqtt_transport", "name": "bus", "enabled": true,
+     "options": {"host": "127.0.0.1", "base_topic": "intel/events"}},
+    {"type": "notify_device", "name": "siren", "enabled": true, "options": {}}
+  ]
+}
+```
+
+`type` resolves to a built-in plugin or a `"module:ClassName"` path for
+out-of-tree plugins. The registry starts each plugin, wires egress plugins to bus
+topics, polls sources each cycle, and fans stored events out to egress.
+
+### Mesh node identity + store-and-forward — `mesh/`
+
+- `mesh/node.py` — a persistent `node_id` (ULID), label, and role
+  (`hub`/`edge`/`relay`) under the platform data dir, so events can record their
+  origin and travel path.
+- `mesh/forwarding.py` — a SQLite-backed store-and-forward queue implementing
+  **gossip / flood-with-suppression**: duplicate `event_id`s and looped events
+  (this node already in `seen_nodes`) are suppressed; otherwise the node stamps
+  itself and enqueues a hop-decremented copy. `ttl_hops` bounds flooding (mesh
+  storm protection). The queue survives power loss because it is persisted.
+
+Phase 1 ships the model + reference algorithm; Phase 2's radios drive it.
+
+## How the engine uses it
+
+`engine/monitor.py` (`MonitorEngine`) gains a platform layer that degrades
+gracefully — if an optional plugin/transport dependency is missing, monitoring
+still runs:
+
+1. **Ingest** — `gather_items()` additionally pulls `registry.poll_sources()`
+   and any buffered inbound transport events, feeding them through the same
+   dedup/location pipeline as native fetchers.
+2. **Egress** — when `process_items()` stores a new alert, it builds an
+   `EmergencyEvent`, offers it to the store-and-forward queue, and publishes it
+   to the bus, where transports/devices/sinks react.
+
+## Roadmap
+
+Phase 1 (this) ships contracts, the kernel, node/forwarding model, and three
+reference plugins (RSS source, MQTT transport, notify device). Later phases —
+multi-channel routing, LoRa/BLE/satellite transports + Rust/Go edge daemons,
+encrypted offline storage, LLM gateway, AI fusion, prompt-injection hardening,
+event signing — each land as plugins or additive modules against this contract.
+See the project plan and the issue tracker (#12/#19/#40, #25–#29, #33/#34, #42,
+#35, #36, #37, #39, #57–#60, #67, #70).

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,41 @@
+"""VigilantCore plugin kernel.
+
+Public surface: the plugin base classes and the :class:`EventBus`/registry that
+turn ingest, transport, device, and automation capabilities into composable
+plugins speaking the :class:`~contracts.EmergencyEvent` contract.
+"""
+
+from __future__ import annotations
+
+from .base import (
+    DevicePlugin,
+    EventBus,
+    Plugin,
+    PluginContext,
+    PluginHealth,
+    SinkPlugin,
+    SourcePlugin,
+    TransportPlugin,
+    TOPIC_HIGH,
+    TOPIC_INGEST,
+    TOPIC_NEW,
+)
+from .loader import BUILTIN_PLUGINS, build_registry
+from .registry import PluginRegistry
+
+__all__ = [
+    "Plugin",
+    "SourcePlugin",
+    "TransportPlugin",
+    "DevicePlugin",
+    "SinkPlugin",
+    "PluginContext",
+    "PluginHealth",
+    "EventBus",
+    "PluginRegistry",
+    "build_registry",
+    "BUILTIN_PLUGINS",
+    "TOPIC_NEW",
+    "TOPIC_HIGH",
+    "TOPIC_INGEST",
+]

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -1,0 +1,205 @@
+"""Plugin contracts and the in-process event bus for VigilantCore.
+
+The kernel turns every capability — fetching sources, talking to other nodes,
+driving local devices, running automations — into a plugin of one of four kinds
+that all speak the :class:`~contracts.EmergencyEvent` contract and report health
+in a single, dashboard-friendly shape (the same telemetry introduced for source
+health in v0.8.0). The :class:`EventBus` replaces the engine's single
+``on_new_alert`` callback with publish/subscribe so any number of plugins can
+react to an event without editing the engine.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+from contracts import EmergencyEvent
+
+logger = logging.getLogger(__name__)
+
+# Bus topics. Egress plugins subscribe to what they care about; the engine
+# publishes every stored alert to NEW and additionally to HIGH when severe.
+TOPIC_NEW = "event.new"          # every newly stored alert
+TOPIC_HIGH = "event.high"        # severity high/critical only
+TOPIC_INGEST = "event.ingest"    # inbound events from transports/sources -> pipeline
+
+# Plugin kinds.
+KIND_SOURCE = "source"
+KIND_TRANSPORT = "transport"
+KIND_DEVICE = "device"
+KIND_SINK = "sink"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+@dataclass
+class PluginHealth:
+    """Uniform health telemetry for every plugin (mirrors source-health v0.8.0)."""
+
+    name: str
+    kind: str
+    enabled: bool = True
+    last_attempt_utc: Optional[str] = None
+    last_success_utc: Optional[str] = None
+    last_error_utc: Optional[str] = None
+    last_error: Optional[str] = None
+    attempt_count: int = 0
+    success_count: int = 0
+    error_count: int = 0
+    last_latency_ms: Optional[float] = None
+    last_item_count: int = 0
+
+    def record_success(self, *, latency_ms: float = 0.0, item_count: int = 0) -> None:
+        now = _now_iso()
+        self.last_attempt_utc = now
+        self.last_success_utc = now
+        self.attempt_count += 1
+        self.success_count += 1
+        self.last_latency_ms = round(max(0.0, float(latency_ms)), 2)
+        self.last_item_count = max(0, int(item_count))
+        self.last_error = None
+
+    def record_error(self, message: str, *, latency_ms: float = 0.0) -> None:
+        now = _now_iso()
+        self.last_attempt_utc = now
+        self.last_error_utc = now
+        self.attempt_count += 1
+        self.error_count += 1
+        self.last_latency_ms = round(max(0.0, float(latency_ms)), 2)
+        self.last_error = (message or "error")[:240].strip() or "error"
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "enabled": self.enabled,
+            "last_attempt_utc": self.last_attempt_utc,
+            "last_success_utc": self.last_success_utc,
+            "last_error_utc": self.last_error_utc,
+            "last_error": self.last_error,
+            "attempt_count": self.attempt_count,
+            "success_count": self.success_count,
+            "error_count": self.error_count,
+            "last_latency_ms": self.last_latency_ms,
+            "last_item_count": self.last_item_count,
+        }
+
+
+Subscriber = Callable[[EmergencyEvent], None]
+
+
+class EventBus:
+    """Thread-safe, synchronous, in-process publish/subscribe for events.
+
+    Handlers are isolated: one failing subscriber never blocks the others or the
+    publisher. This is deliberately simple — the same semantics work on a Pi as
+    in tests, and durable cross-node delivery is the transports' job, not the bus'.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._subs: Dict[str, List[Subscriber]] = {}
+
+    def subscribe(self, topic: str, handler: Subscriber) -> None:
+        with self._lock:
+            self._subs.setdefault(topic, []).append(handler)
+
+    def unsubscribe(self, topic: str, handler: Subscriber) -> None:
+        with self._lock:
+            handlers = self._subs.get(topic)
+            if handlers and handler in handlers:
+                handlers.remove(handler)
+
+    def publish(self, topic: str, event: EmergencyEvent) -> int:
+        """Deliver ``event`` to every subscriber of ``topic``. Returns delivery count."""
+
+        with self._lock:
+            handlers = list(self._subs.get(topic, ()))
+        delivered = 0
+        for handler in handlers:
+            try:
+                handler(event)
+                delivered += 1
+            except Exception:  # pragma: no cover - defensive isolation
+                logger.exception("EventBus subscriber on %s failed", topic)
+        return delivered
+
+
+@dataclass
+class PluginContext:
+    """Everything a plugin needs from the host at startup."""
+
+    bus: EventBus
+    config: Any
+    node_id: Optional[str] = None
+    options: Dict[str, Any] = field(default_factory=dict)
+
+
+class Plugin(ABC):
+    """Base class for all plugins."""
+
+    kind: str = "plugin"
+
+    def __init__(self, name: str, options: Optional[Dict[str, Any]] = None) -> None:
+        self.name = name
+        self.options = options or {}
+        self.health = PluginHealth(name=name, kind=self.kind)
+
+    def start(self, ctx: PluginContext) -> None:
+        """Acquire resources and wire bus subscriptions. Override as needed."""
+
+    def stop(self) -> None:
+        """Release resources. Override as needed."""
+
+    def health_snapshot(self) -> Dict[str, Any]:
+        return self.health.as_dict()
+
+
+class SourcePlugin(Plugin):
+    """Produces events. The engine calls :meth:`poll` each cycle and ingests the
+    returned events through the normal dedup/store pipeline."""
+
+    kind = KIND_SOURCE
+
+    @abstractmethod
+    async def poll(self, ctx: PluginContext) -> List[EmergencyEvent]:
+        """Return any new events discovered this cycle (may be empty)."""
+
+
+class TransportPlugin(Plugin):
+    """Bidirectional link to other nodes/devices. Outbound via :meth:`send`
+    (the kernel subscribes it to the bus); inbound by publishing received events
+    to ``TOPIC_INGEST`` so they re-enter the pipeline."""
+
+    kind = KIND_TRANSPORT
+
+    @abstractmethod
+    def send(self, event: EmergencyEvent) -> None:
+        """Transmit an event to peers/devices over this transport."""
+
+
+class DevicePlugin(Plugin):
+    """Local output device (siren, display, GPIO relay, native notification)."""
+
+    kind = KIND_DEVICE
+
+    @abstractmethod
+    def render(self, event: EmergencyEvent) -> None:
+        """Present/actuate the event on the local device."""
+
+
+class SinkPlugin(Plugin):
+    """Side-effecting consumer (webhook, shell action, digest, export)."""
+
+    kind = KIND_SINK
+
+    @abstractmethod
+    def handle(self, event: EmergencyEvent) -> None:
+        """Process the event (fire webhook, append to digest, etc.)."""

--- a/plugins/builtin/__init__.py
+++ b/plugins/builtin/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in reference plugins shipped with VigilantCore."""

--- a/plugins/builtin/mqtt_transport.py
+++ b/plugins/builtin/mqtt_transport.py
@@ -1,0 +1,122 @@
+"""MQTT transport plugin — publishes events to the ShelfCast-compatible bus.
+
+Outbound: every event is published as schema-valid JSON to
+``<base_topic>/normalized``; high/critical events additionally go to
+``<base_topic>/high_priority`` (issues #57/#58/#59, schema #60). Inbound:
+when ``subscribe_inbound`` is set, events received on ``<base_topic>/ingest``
+are republished to the local bus' ``TOPIC_INGEST`` so they re-enter the pipeline.
+
+``paho-mqtt`` is imported lazily and a client can be injected via
+``options['client']`` for tests, so importing this module never requires a broker.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from contracts import EmergencyEvent
+
+from ..base import PluginContext, TransportPlugin, TOPIC_INGEST
+
+logger = logging.getLogger(__name__)
+
+NORMALIZED_SUFFIX = "normalized"
+HIGH_PRIORITY_SUFFIX = "high_priority"
+INGEST_SUFFIX = "ingest"
+_HIGH_SEVERITIES = {"high", "critical"}
+
+
+class MqttTransportPlugin(TransportPlugin):
+    def __init__(self, name: str, options: Optional[dict[str, Any]] = None) -> None:
+        super().__init__(name, options)
+        self._client = self.options.get("client")  # injectable for tests
+        self._ctx: Optional[PluginContext] = None
+        self._base_topic = str(self.options.get("base_topic", "intel/events")).rstrip("/")
+        self._validate = bool(self.options.get("validate", True))
+
+    # ----- lifecycle -----------------------------------------------------
+    def start(self, ctx: PluginContext) -> None:
+        self._ctx = ctx
+        if self._client is None:
+            self._client = self._connect()
+        if self._client is not None and self.options.get("subscribe_inbound"):
+            self._subscribe_inbound()
+
+    def _connect(self):
+        try:
+            import paho.mqtt.client as mqtt  # type: ignore
+        except Exception:
+            logger.warning(
+                "paho-mqtt not installed; MQTT transport %s is inert (install paho-mqtt)",
+                self.name,
+            )
+            return None
+        host = self.options.get("host", "127.0.0.1")
+        port = int(self.options.get("port", 1883))
+        client = mqtt.Client()
+        username = self.options.get("username")
+        if username:
+            client.username_pw_set(username, self.options.get("password"))
+        try:
+            client.connect(host, port, keepalive=int(self.options.get("keepalive", 60)))
+            client.loop_start()
+        except Exception as exc:
+            logger.warning("MQTT transport %s failed to connect: %s", self.name, exc)
+            self.health.record_error(f"connect failed: {exc}")
+            return None
+        return client
+
+    def _subscribe_inbound(self) -> None:
+        topic = f"{self._base_topic}/{INGEST_SUFFIX}"
+
+        def _on_message(_client, _userdata, message) -> None:
+            try:
+                event = EmergencyEvent.from_json(message.payload)
+                if self._ctx is not None:
+                    self._ctx.bus.publish(TOPIC_INGEST, event)
+            except Exception:
+                logger.exception("MQTT transport %s: bad inbound payload", self.name)
+
+        try:
+            self._client.on_message = _on_message
+            self._client.subscribe(topic)
+        except Exception as exc:  # pragma: no cover - broker dependent
+            logger.warning("MQTT transport %s inbound subscribe failed: %s", self.name, exc)
+
+    def stop(self) -> None:
+        client = self._client
+        if client is None:
+            return
+        for closer in ("loop_stop", "disconnect"):
+            try:
+                getattr(client, closer)()
+            except Exception:
+                pass
+
+    # ----- outbound ------------------------------------------------------
+    def send(self, event: EmergencyEvent) -> None:
+        if self._client is None:
+            return
+        if self._validate:
+            event.validate()  # raises on contract violation before we publish
+        payload = event.to_json()
+        self._publish(f"{self._base_topic}/{NORMALIZED_SUFFIX}", payload)
+        if str(event.severity).lower() in _HIGH_SEVERITIES:
+            self._publish(f"{self._base_topic}/{HIGH_PRIORITY_SUFFIX}", payload)
+
+    def _publish(self, topic: str, payload: str) -> None:
+        result = self._client.publish(topic, payload)
+        # paho returns an object with rc; injected fakes may return anything.
+        rc = getattr(result, "rc", 0)
+        if rc not in (0, None):
+            raise RuntimeError(f"MQTT publish to {topic} failed rc={rc}")
+        logger.debug("MQTT %s -> %s (%d bytes)", self.name, topic, len(payload))
+
+    def published_topics_for(self, event: EmergencyEvent) -> list[str]:
+        """Topics ``send`` would target for ``event`` (handy for tests/docs)."""
+
+        topics = [f"{self._base_topic}/{NORMALIZED_SUFFIX}"]
+        if str(event.severity).lower() in _HIGH_SEVERITIES:
+            topics.append(f"{self._base_topic}/{HIGH_PRIORITY_SUFFIX}")
+        return topics

--- a/plugins/builtin/notify_device.py
+++ b/plugins/builtin/notify_device.py
@@ -1,0 +1,57 @@
+"""Notification device plugin — the reference DevicePlugin.
+
+By default it renders high/critical events as a local notification: it shells
+out to ``notify-send`` when available, otherwise logs a formatted line. Rendered
+events are also retained in ``self.rendered`` so tests and the dashboard can
+inspect what was surfaced without a display. Real output devices (sirens, GPIO
+relays, TTS — issue #29) follow this same ``render`` shape.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from typing import List
+
+from contracts import EmergencyEvent
+
+from ..base import DevicePlugin, PluginContext
+
+logger = logging.getLogger(__name__)
+
+
+class NotifyDevicePlugin(DevicePlugin):
+    def __init__(self, name: str, options=None) -> None:
+        super().__init__(name, options)
+        self.rendered: List[dict] = []
+        self._use_desktop = bool(self.options.get("desktop", True))
+        self._notify_send = shutil.which("notify-send") if self._use_desktop else None
+
+    def start(self, ctx: PluginContext) -> None:
+        logger.info(
+            "Notify device %s ready (desktop=%s)",
+            self.name,
+            bool(self._notify_send),
+        )
+
+    def render(self, event: EmergencyEvent) -> None:
+        title = f"[{event.severity.upper()}] {event.hazard_type}: {event.title}"
+        body_parts = [event.summary or event.predictive_outcome or ""]
+        location = (event.location or {}).get("name")
+        if location:
+            body_parts.append(f"Location: {location}")
+        body = " — ".join(p for p in body_parts if p)
+
+        self.rendered.append({"title": title, "body": body, "event_id": event.event_id})
+        if self._notify_send:
+            try:
+                subprocess.run(
+                    [self._notify_send, "-u", "critical", title, body],
+                    check=False,
+                    timeout=5,
+                )
+                return
+            except Exception:  # pragma: no cover - environment dependent
+                logger.debug("notify-send failed for %s; logging instead", self.name)
+        logger.warning("NOTIFY %s :: %s :: %s", self.name, title, body)

--- a/plugins/builtin/rss_source.py
+++ b/plugins/builtin/rss_source.py
@@ -1,0 +1,90 @@
+"""RSS source plugin — the reference SourcePlugin proving the ingest seam.
+
+This wraps plain RSS fetching as a first-class plugin: it returns
+:class:`~contracts.EmergencyEvent` objects built through the existing
+``normalize_event_payload`` adapter, so events produced here flow through the
+same dedup/store pipeline as the engine's native fetchers. New inbound
+transports (LoRa-in #25, MQTT-in #57, sensors #36) follow this exact pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from time import perf_counter
+from typing import List
+
+import feedparser
+import httpx
+
+from contracts import EmergencyEvent
+from utils.event_normalization import normalize_event_payload
+
+from ..base import PluginContext, SourcePlugin
+
+logger = logging.getLogger(__name__)
+
+
+class RssSourcePlugin(SourcePlugin):
+    """Fetch one or more RSS feeds listed in ``options['feeds']``."""
+
+    async def poll(self, ctx: PluginContext) -> List[EmergencyEvent]:
+        feeds = list(self.options.get("feeds", []) or [])
+        if not feeds:
+            return []
+        started = perf_counter()
+        events: List[EmergencyEvent] = []
+        config = ctx.config
+        location_name = getattr(config, "location_name", "") if config else ""
+        zip_code = getattr(config, "zip_code", None) if config else None
+        latitude = getattr(config, "latitude", None) if config else None
+        longitude = getattr(config, "longitude", None) if config else None
+
+        timeout = httpx.Timeout(self.options.get("timeout", 20))
+        try:
+            async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+                for feed_url in feeds:
+                    try:
+                        resp = await client.get(feed_url)
+                        resp.raise_for_status()
+                        parsed = await asyncio.to_thread(feedparser.parse, resp.text)
+                    except Exception as exc:
+                        logger.debug("RSS plugin %s: feed %s failed: %s", self.name, feed_url, exc)
+                        continue
+                    feed_title = parsed.feed.get("title", "RSS")
+                    for entry in parsed.entries:
+                        url = entry.get("link")
+                        if not url:
+                            continue
+                        title = entry.get("title", "(no title)")
+                        snippet = entry.get("summary", "")
+                        published = entry.get("published") or entry.get("updated")
+                        normalized = normalize_event_payload(
+                            source_event={"published_at": published, "source": feed_title},
+                            impact_score=5,
+                            is_relevant=True,
+                            location_name=location_name or "",
+                            source_kind="rss",
+                            zip_code=zip_code,
+                            latitude=latitude,
+                            longitude=longitude,
+                        )
+                        events.append(
+                            EmergencyEvent.from_normalized(
+                                normalized=normalized,
+                                title=title,
+                                snippet=snippet,
+                                impact_score=5,
+                                url=url,
+                                source=feed_title,
+                                source_kind="rss",
+                                origin_node_id=ctx.node_id,
+                            )
+                        )
+        except Exception as exc:  # pragma: no cover - network defensive
+            self.health.record_error(str(exc), latency_ms=(perf_counter() - started) * 1000)
+            return events
+        self.health.record_success(
+            latency_ms=(perf_counter() - started) * 1000, item_count=len(events)
+        )
+        return events

--- a/plugins/loader.py
+++ b/plugins/loader.py
@@ -1,0 +1,98 @@
+"""Config-driven plugin loader (plugin loader v0, issue #12).
+
+Reads the ``plugins`` list from :class:`~utils.config.AppConfig` and builds a
+started :class:`~plugins.registry.PluginRegistry`. Each entry looks like::
+
+    {"type": "rss_source", "name": "local-rss", "enabled": true,
+     "options": {"feeds": ["https://…/rss"]}}
+
+``type`` resolves against the built-in catalog, or as a ``"module:ClassName"``
+path for out-of-tree plugins — the groundwork for the richer Plugin API (#19/#40).
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import Any, List, Optional, Type
+
+from .base import Plugin
+from .builtin.mqtt_transport import MqttTransportPlugin
+from .builtin.notify_device import NotifyDevicePlugin
+from .builtin.rss_source import RssSourcePlugin
+from .registry import PluginRegistry
+
+logger = logging.getLogger(__name__)
+
+# Built-in plugin catalog: type string -> class.
+BUILTIN_PLUGINS: dict[str, Type[Plugin]] = {
+    "rss_source": RssSourcePlugin,
+    "mqtt_transport": MqttTransportPlugin,
+    "notify_device": NotifyDevicePlugin,
+}
+
+
+def resolve_plugin_class(type_name: str) -> Optional[Type[Plugin]]:
+    """Resolve a plugin ``type`` to a class, by catalog name or ``module:Class``."""
+
+    if type_name in BUILTIN_PLUGINS:
+        return BUILTIN_PLUGINS[type_name]
+    if ":" in type_name:
+        module_path, _, class_name = type_name.partition(":")
+        try:
+            module = importlib.import_module(module_path)
+            cls = getattr(module, class_name)
+        except Exception as exc:
+            logger.warning("Could not import plugin %s: %s", type_name, exc)
+            return None
+        if isinstance(cls, type) and issubclass(cls, Plugin):
+            return cls
+        logger.warning("Plugin %s is not a Plugin subclass", type_name)
+        return None
+    logger.warning("Unknown plugin type %r", type_name)
+    return None
+
+
+def build_plugin(entry: dict[str, Any]) -> Optional[Plugin]:
+    """Instantiate a single plugin from a config entry, or ``None`` if disabled/invalid."""
+
+    if not isinstance(entry, dict):
+        return None
+    if not entry.get("enabled", True):
+        return None
+    type_name = entry.get("type") or entry.get("name")
+    if not type_name:
+        logger.warning("Plugin entry missing 'type': %r", entry)
+        return None
+    cls = resolve_plugin_class(str(type_name))
+    if cls is None:
+        return None
+    name = str(entry.get("name") or type_name)
+    options = entry.get("options") or {}
+    try:
+        return cls(name=name, options=options)
+    except Exception as exc:
+        logger.warning("Failed to instantiate plugin %s: %s", name, exc)
+        return None
+
+
+def build_registry(
+    config: Any = None,
+    node_id: Optional[str] = None,
+    *,
+    start: bool = True,
+) -> PluginRegistry:
+    """Build (and by default start) a registry from ``config.plugins``."""
+
+    registry = PluginRegistry(config=config, node_id=node_id)
+    entries: List[dict[str, Any]] = []
+    if config is not None:
+        entries = list(getattr(config, "plugins", None) or [])
+    for entry in entries:
+        plugin = build_plugin(entry)
+        if plugin is not None:
+            registry.register(plugin)
+            logger.info("Loaded plugin %s (%s)", plugin.name, plugin.kind)
+    if start:
+        registry.start_all()
+    return registry

--- a/plugins/registry.py
+++ b/plugins/registry.py
@@ -1,0 +1,149 @@
+"""Plugin lifecycle + event routing registry.
+
+The registry owns the :class:`EventBus`, starts/stops plugins, wires egress
+plugins (transport/device/sink) to the bus topics they care about, and gives the
+engine two integration points: :meth:`poll_sources` (pull new events from source
+plugins each cycle) and :meth:`publish` (fan a stored event out to all egress
+plugins). It is intentionally inert when no plugins are configured, so default
+installs behave exactly as before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+from contracts import EmergencyEvent
+
+from .base import (
+    DevicePlugin,
+    EventBus,
+    Plugin,
+    PluginContext,
+    SinkPlugin,
+    SourcePlugin,
+    TransportPlugin,
+    TOPIC_HIGH,
+    TOPIC_INGEST,
+    TOPIC_NEW,
+)
+
+logger = logging.getLogger(__name__)
+
+_HIGH_SEVERITIES = {"high", "critical"}
+
+
+class PluginRegistry:
+    def __init__(self, config: Any = None, node_id: Optional[str] = None) -> None:
+        self.config = config
+        self.node_id = node_id
+        self.bus = EventBus()
+        self._plugins: List[Plugin] = []
+        self._started = False
+
+    # ----- registration / lifecycle -------------------------------------
+    def register(self, plugin: Plugin) -> None:
+        self._plugins.append(plugin)
+
+    @property
+    def plugins(self) -> List[Plugin]:
+        return list(self._plugins)
+
+    def sources(self) -> List[SourcePlugin]:
+        return [p for p in self._plugins if isinstance(p, SourcePlugin)]
+
+    def _context_for(self, plugin: Plugin) -> PluginContext:
+        return PluginContext(
+            bus=self.bus,
+            config=self.config,
+            node_id=self.node_id,
+            options=plugin.options,
+        )
+
+    def start_all(self) -> None:
+        if self._started:
+            return
+        for plugin in self._plugins:
+            try:
+                plugin.start(self._context_for(plugin))
+                self._wire_egress(plugin)
+            except Exception:
+                logger.exception("Failed to start plugin %s", plugin.name)
+                plugin.health.record_error("start failed")
+        self._started = True
+
+    def _wire_egress(self, plugin: Plugin) -> None:
+        """Subscribe egress plugins to the appropriate bus topics."""
+
+        if isinstance(plugin, TransportPlugin):
+            # Transports get every event; they decide normal vs high internally.
+            self.bus.subscribe(TOPIC_NEW, self._guard(plugin, plugin.send))
+        elif isinstance(plugin, DevicePlugin):
+            # Devices (sirens/displays) default to high-severity only; override
+            # with options {"min_severity": "low"} to receive everything.
+            topic = TOPIC_NEW if plugin.options.get("min_severity") == "low" else TOPIC_HIGH
+            self.bus.subscribe(topic, self._guard(plugin, plugin.render))
+        elif isinstance(plugin, SinkPlugin):
+            self.bus.subscribe(TOPIC_NEW, self._guard(plugin, plugin.handle))
+
+    def _guard(self, plugin: Plugin, fn: Callable[[EmergencyEvent], None]):
+        """Wrap an egress handler so it records health and never raises into the bus."""
+
+        def _handler(event: EmergencyEvent) -> None:
+            try:
+                fn(event)
+                plugin.health.record_success(item_count=1)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.exception("Plugin %s handler failed", plugin.name)
+                plugin.health.record_error(str(exc))
+
+        return _handler
+
+    def stop_all(self) -> None:
+        for plugin in self._plugins:
+            try:
+                plugin.stop()
+            except Exception:
+                logger.exception("Failed to stop plugin %s", plugin.name)
+        self._started = False
+
+    # ----- engine integration -------------------------------------------
+    async def poll_sources(self) -> List[EmergencyEvent]:
+        """Collect new events from all source plugins concurrently."""
+
+        source_plugins = self.sources()
+        if not source_plugins:
+            return []
+        ctx_map = {p: self._context_for(p) for p in source_plugins}
+        results = await asyncio.gather(
+            *[p.poll(ctx_map[p]) for p in source_plugins],
+            return_exceptions=True,
+        )
+        events: List[EmergencyEvent] = []
+        for plugin, result in zip(source_plugins, results):
+            if isinstance(result, Exception):
+                logger.warning("Source plugin %s poll failed: %s", plugin.name, result)
+                plugin.health.record_error(str(result))
+                continue
+            plugin.health.record_success(item_count=len(result))
+            events.extend(result)
+        return events
+
+    def publish(self, event: EmergencyEvent) -> None:
+        """Fan a stored event out to egress plugins (NEW, plus HIGH when severe)."""
+
+        if not self._plugins:
+            return
+        self.bus.publish(TOPIC_NEW, event)
+        if str(event.severity).lower() in _HIGH_SEVERITIES:
+            self.bus.publish(TOPIC_HIGH, event)
+
+    def subscribe_ingest(self, handler: Callable[[EmergencyEvent], None]) -> None:
+        """Register the engine's handler for inbound events from transports."""
+
+        self.bus.subscribe(TOPIC_INGEST, handler)
+
+    # ----- introspection -------------------------------------------------
+    def health(self) -> List[Dict[str, Any]]:
+        return [p.health_snapshot() for p in self._plugins]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ flask
 beautifulsoup4
 psutil
 jsonschema
+paho-mqtt

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from contracts import EmergencyEvent
+from plugins import EventBus, TOPIC_INGEST, TOPIC_NEW, build_registry
+from plugins.base import PluginContext, SourcePlugin
+from plugins.builtin.mqtt_transport import MqttTransportPlugin
+from plugins.builtin.notify_device import NotifyDevicePlugin
+from plugins.loader import build_plugin, resolve_plugin_class
+
+
+class FakeMqttClient:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, str]] = []
+
+    def publish(self, topic, payload):
+        self.published.append((topic, payload))
+        return type("R", (), {"rc": 0})()
+
+
+class _Cfg:
+    """Minimal config-like object exposing a plugins list."""
+
+    def __init__(self, plugins):
+        self.plugins = plugins
+        self.location_name = "Test County"
+        self.zip_code = None
+        self.latitude = None
+        self.longitude = None
+
+
+def _event(severity: str = "high") -> EmergencyEvent:
+    return EmergencyEvent(
+        title="Test hazard",
+        hazard_type="storm",
+        severity=severity,
+        confidence=0.7,
+        impact_score=8 if severity in ("high", "critical") else 3,
+    )
+
+
+class EventBusTests(unittest.TestCase):
+    def test_publish_delivers_to_subscribers(self) -> None:
+        bus = EventBus()
+        received = []
+        bus.subscribe(TOPIC_NEW, received.append)
+        delivered = bus.publish(TOPIC_NEW, _event())
+        self.assertEqual(delivered, 1)
+        self.assertEqual(len(received), 1)
+
+    def test_failing_subscriber_is_isolated(self) -> None:
+        bus = EventBus()
+        ok = []
+
+        def boom(_event):
+            raise RuntimeError("kaboom")
+
+        bus.subscribe(TOPIC_NEW, boom)
+        bus.subscribe(TOPIC_NEW, ok.append)
+        bus.publish(TOPIC_NEW, _event())  # must not raise
+        self.assertEqual(len(ok), 1)
+
+    def test_unsubscribe(self) -> None:
+        bus = EventBus()
+        received = []
+        bus.subscribe(TOPIC_NEW, received.append)
+        bus.unsubscribe(TOPIC_NEW, received.append)
+        bus.publish(TOPIC_NEW, _event())
+        self.assertEqual(received, [])
+
+
+class RegistryRoutingTests(unittest.TestCase):
+    def test_high_severity_routes_to_device_and_transport(self) -> None:
+        fake = FakeMqttClient()
+        cfg = _Cfg([
+            {"type": "mqtt_transport", "name": "bus",
+             "options": {"client": fake, "base_topic": "intel/events"}},
+            {"type": "notify_device", "name": "siren",
+             "options": {"desktop": False}},
+        ])
+        registry = build_registry(cfg, node_id="NODE-A")
+        registry.publish(_event("critical"))
+
+        topics = [t for t, _ in fake.published]
+        self.assertIn("intel/events/normalized", topics)
+        self.assertIn("intel/events/high_priority", topics)
+        siren = next(p for p in registry.plugins if p.name == "siren")
+        self.assertEqual(len(siren.rendered), 1)
+
+    def test_low_severity_skips_default_device_and_high_topic(self) -> None:
+        fake = FakeMqttClient()
+        cfg = _Cfg([
+            {"type": "mqtt_transport", "name": "bus",
+             "options": {"client": fake, "base_topic": "intel/events"}},
+            {"type": "notify_device", "name": "siren",
+             "options": {"desktop": False}},
+        ])
+        registry = build_registry(cfg, node_id="NODE-A")
+        registry.publish(_event("low"))
+
+        topics = [t for t, _ in fake.published]
+        self.assertEqual(topics, ["intel/events/normalized"])  # no high_priority
+        siren = next(p for p in registry.plugins if p.name == "siren")
+        self.assertEqual(siren.rendered, [])  # device defaults to high only
+
+    def test_device_min_severity_low_receives_all(self) -> None:
+        cfg = _Cfg([
+            {"type": "notify_device", "name": "log",
+             "options": {"min_severity": "low", "desktop": False}},
+        ])
+        registry = build_registry(cfg, node_id="NODE-A")
+        registry.publish(_event("low"))
+        log = registry.plugins[0]
+        self.assertEqual(len(log.rendered), 1)
+
+    def test_disabled_plugin_not_loaded(self) -> None:
+        cfg = _Cfg([
+            {"type": "notify_device", "name": "off", "enabled": False, "options": {}},
+        ])
+        registry = build_registry(cfg, node_id="NODE-A")
+        self.assertEqual(registry.plugins, [])
+
+    def test_inert_registry_with_no_plugins(self) -> None:
+        registry = build_registry(_Cfg([]), node_id="NODE-A")
+        # publish must be a no-op and never raise.
+        registry.publish(_event("critical"))
+        self.assertEqual(registry.health(), [])
+
+
+class SourcePluginPollTests(unittest.TestCase):
+    def test_poll_sources_collects_events(self) -> None:
+        class StubSource(SourcePlugin):
+            async def poll(self, ctx: PluginContext):
+                return [_event("medium"), _event("medium")]
+
+        registry = build_registry(_Cfg([]), node_id="NODE-A")
+        registry.register(StubSource("stub"))
+        events = asyncio.run(registry.poll_sources())
+        self.assertEqual(len(events), 2)
+
+    def test_poll_sources_isolates_failures(self) -> None:
+        class BadSource(SourcePlugin):
+            async def poll(self, ctx: PluginContext):
+                raise RuntimeError("nope")
+
+        class GoodSource(SourcePlugin):
+            async def poll(self, ctx: PluginContext):
+                return [_event("low")]
+
+        registry = build_registry(_Cfg([]), node_id="NODE-A")
+        registry.register(BadSource("bad"))
+        registry.register(GoodSource("good"))
+        events = asyncio.run(registry.poll_sources())
+        self.assertEqual(len(events), 1)
+
+
+class IngestSubscriptionTests(unittest.TestCase):
+    def test_inbound_events_reach_subscriber(self) -> None:
+        registry = build_registry(_Cfg([]), node_id="NODE-A")
+        got = []
+        registry.subscribe_ingest(got.append)
+        registry.bus.publish(TOPIC_INGEST, _event())
+        self.assertEqual(len(got), 1)
+
+
+class LoaderTests(unittest.TestCase):
+    def test_resolve_builtin_and_module_path(self) -> None:
+        self.assertIs(resolve_plugin_class("notify_device"), NotifyDevicePlugin)
+        cls = resolve_plugin_class(
+            "plugins.builtin.mqtt_transport:MqttTransportPlugin"
+        )
+        self.assertIs(cls, MqttTransportPlugin)
+        self.assertIsNone(resolve_plugin_class("does_not_exist"))
+
+    def test_build_plugin_respects_enabled(self) -> None:
+        self.assertIsNone(build_plugin({"type": "notify_device", "enabled": False}))
+        plugin = build_plugin({"type": "notify_device", "name": "n"})
+        self.assertIsInstance(plugin, NotifyDevicePlugin)
+
+
+class MqttTransportTests(unittest.TestCase):
+    def test_validate_before_publish(self) -> None:
+        fake = FakeMqttClient()
+        plugin = MqttTransportPlugin("bus", {"client": fake, "base_topic": "intel/events"})
+        plugin.start(PluginContext(bus=EventBus(), config=None, node_id="N"))
+        # An invalid event must be rejected before any publish happens.
+        bad = EmergencyEvent(title="x", severity="not-real")
+        with self.assertRaises(ValueError):
+            plugin.send(bad)
+        self.assertEqual(fake.published, [])
+
+    def test_published_topics_for(self) -> None:
+        plugin = MqttTransportPlugin("bus", {"base_topic": "intel/events"})
+        self.assertEqual(
+            plugin.published_topics_for(_event("low")),
+            ["intel/events/normalized"],
+        )
+        self.assertEqual(
+            plugin.published_topics_for(_event("critical")),
+            ["intel/events/normalized", "intel/events/high_priority"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Phase 1 platform series — PR 2 of 4** · base: `release/0.10.0` (stacked; review/merge after PR #72)

Adds the plugin kernel that turns ingest, transport, device, and automation capabilities into composable plugins speaking the `EmergencyEvent` contract.

### Adds
- `plugins/base.py` — `SourcePlugin` / `TransportPlugin` / `DevicePlugin` / `SinkPlugin` + an in-process **`EventBus`** (pub/sub) that supersedes the engine's single `on_new_alert` callback; uniform `PluginHealth` telemetry (v0.8.0 shape).
- `plugins/registry.py` + `plugins/loader.py` — config-driven load (`{type, name, enabled, options}`; `type` resolves to a built-in or `module:ClassName`). Inert when no plugins configured.
- `plugins/builtin/` — **RSS source** (ingest seam), **MQTT transport** (publishes schema-valid events to `intel/events/normalized` + `intel/events/high_priority`), **notify device**.
- `tests/test_plugin_registry.py`; `paho-mqtt` dep; `docs/architecture.md`.

### Testing
102 tests pass; ruff clean.

> Note: base is `release/0.10.0`, so the diff is just this layer. Once #72 merges to `main`, retarget this PR to `main` (or merge #72 first). Knocks out the publish side of #57/#58/#59; advances #12/#19/#40.