### PR TITLE
feat(mesh): node identity + store-and-forward queue (0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to VigilantCore will be documented in this file.
 
+## [0.12.0] - 2026-06-19
+
+### Added
+
+- **Mesh node identity** (`mesh/node.py`): a persistent `node_id` (ULID), label, and role (`hub`/`edge`/`relay`) stored under the platform data dir, so events can record their origin and travel path across nodes.
+- **Store-and-forward queue** (`mesh/forwarding.py`): a SQLite-backed gossip / flood-with-suppression model for offline propagation. Duplicate `event_id`s and looped events (this node already in `seen_nodes`) are suppressed; otherwise the node stamps itself and enqueues a hop-decremented copy. `ttl_hops` bounds flooding (mesh storm protection). The queue and dedup memory persist, so a field node resumes intact after power loss.
+- **Tests** (`tests/test_store_and_forward.py`) covering stable node identity, dedup, loop prevention, TTL bounding, and restart persistence.
+
+This ships the model and reference algorithm; the radios that drive it arrive in a later phase.
+
 ## [0.11.0] - 2026-06-19
 
 ### Added

--- a/mesh/__init__.py
+++ b/mesh/__init__.py
@@ -1,0 +1,14 @@
+"""Mesh node identity and store-and-forward primitives for VigilantCore."""
+
+from __future__ import annotations
+
+from .forwarding import ForwardingQueue, OfferResult
+from .node import Node, load_or_create_node, node_path
+
+__all__ = [
+    "Node",
+    "load_or_create_node",
+    "node_path",
+    "ForwardingQueue",
+    "OfferResult",
+]

--- a/mesh/forwarding.py
+++ b/mesh/forwarding.py
@@ -21,6 +21,7 @@ power resumes with its dedup memory and pending forwards intact.
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -28,6 +29,8 @@ from typing import Callable, List
 
 from contracts import EmergencyEvent
 from utils import database
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -60,8 +63,20 @@ class ForwardingQueue:
         self._connect = connect
         self.init_schema()
 
+    def _open(self) -> sqlite3.Connection:
+        """Open a connection with ``sqlite3.Row`` factory.
+
+        The injected ``connect=`` seam may hand back a plain connection (tuple
+        rows); forcing the row factory here lets us address columns by name
+        without raising on those connections.
+        """
+
+        conn = self._connect()
+        conn.row_factory = sqlite3.Row
+        return conn
+
     def init_schema(self) -> None:
-        with self._connect() as conn:
+        with self._open() as conn:
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS mesh_seen_events (
@@ -89,31 +104,36 @@ class ForwardingQueue:
 
     # ----- dedup memory --------------------------------------------------
     def has_seen(self, event_id: str) -> bool:
-        with self._connect() as conn:
+        with self._open() as conn:
             cur = conn.execute(
                 "SELECT 1 FROM mesh_seen_events WHERE event_id = ? LIMIT 1", (event_id,)
             )
             return cur.fetchone() is not None
 
-    def _record_seen(self, conn: sqlite3.Connection, event_id: str) -> None:
-        conn.execute(
-            "INSERT OR IGNORE INTO mesh_seen_events (event_id, first_seen_utc) VALUES (?, ?)",
-            (event_id, _now_iso()),
-        )
-
     # ----- core gossip logic --------------------------------------------
     def offer(self, event: EmergencyEvent) -> OfferResult:
-        """Consider an event for forwarding; suppress loops and duplicates."""
+        """Consider an event for forwarding; suppress loops and duplicates.
+
+        Dedup is atomic: the ``event_id`` is inserted into ``mesh_seen_events``
+        (PRIMARY KEY) inside one transaction, so concurrent offers of the same
+        event race on the unique constraint and exactly one wins — a separate
+        has_seen() pre-check would let both be accepted under threaded use.
+        """
 
         if self.node_id in event.seen_nodes:
             return OfferResult("looped", False)
-        if self.has_seen(event.event_id):
-            return OfferResult("duplicate", False)
 
-        event.mark_seen(self.node_id)
-        will_forward = event.ttl_hops > 0
-        with self._connect() as conn:
-            self._record_seen(conn, event.event_id)
+        now = _now_iso()
+        with self._open() as conn:
+            try:
+                conn.execute(
+                    "INSERT INTO mesh_seen_events (event_id, first_seen_utc) VALUES (?, ?)",
+                    (event.event_id, now),
+                )
+            except sqlite3.IntegrityError:
+                return OfferResult("duplicate", False)
+            event.mark_seen(self.node_id)
+            will_forward = event.ttl_hops > 0
             if will_forward:
                 forward_copy = event.decremented()
                 conn.execute(
@@ -126,37 +146,51 @@ class ForwardingQueue:
                         forward_copy.event_id,
                         forward_copy.to_json(),
                         forward_copy.ttl_hops,
-                        _now_iso(),
+                        now,
                     ),
                 )
         return OfferResult("new", will_forward)
 
     # ----- queue draining (transports call these) ------------------------
     def pending(self, limit: int = 100) -> List[EmergencyEvent]:
-        """Return enqueued, not-yet-forwarded events (oldest first)."""
+        """Return enqueued, not-yet-forwarded events (oldest first).
 
-        with self._connect() as conn:
+        Rows that can't be decoded are marked forwarded so a corrupt payload
+        can't permanently wedge the queue (``pending_count`` would otherwise never
+        drain and transports would spin on it)."""
+
+        events: List[EmergencyEvent] = []
+        bad_ids: List[str] = []
+        with self._open() as conn:
             cur = conn.execute(
-                "SELECT payload_json FROM mesh_forward_queue "
+                "SELECT event_id, payload_json FROM mesh_forward_queue "
                 "WHERE forwarded = 0 ORDER BY enqueued_utc ASC LIMIT ?",
                 (limit,),
             )
-            rows = cur.fetchall()
-        events: List[EmergencyEvent] = []
-        for row in rows:
-            try:
-                # Trusted local storage we wrote ourselves: decode leniently so the
-                # original trust tier/signature is preserved for relay (strict
-                # decode would clamp it as if it were untrusted inbound).
-                events.append(
-                    EmergencyEvent.from_json(row["payload_json"], strict=False)
+            for row in cur.fetchall():
+                try:
+                    # Trusted local storage we wrote ourselves: decode leniently so
+                    # the original trust tier/signature is preserved for relay
+                    # (strict decode would clamp it as untrusted inbound).
+                    events.append(
+                        EmergencyEvent.from_json(row["payload_json"], strict=False)
+                    )
+                except (KeyError, ValueError, json.JSONDecodeError, TypeError):
+                    bad_ids.append(row["event_id"])
+            for event_id in bad_ids:
+                conn.execute(
+                    "UPDATE mesh_forward_queue SET forwarded = 1, attempts = attempts + 1 "
+                    "WHERE event_id = ?",
+                    (event_id,),
                 )
-            except (KeyError, ValueError, json.JSONDecodeError, TypeError):
-                continue
+        if bad_ids:
+            logger.warning(
+                "Dropped %d undecodable mesh forward-queue row(s)", len(bad_ids)
+            )
         return events
 
     def mark_forwarded(self, event_id: str) -> None:
-        with self._connect() as conn:
+        with self._open() as conn:
             conn.execute(
                 "UPDATE mesh_forward_queue SET forwarded = 1, attempts = attempts + 1 "
                 "WHERE event_id = ?",
@@ -164,7 +198,7 @@ class ForwardingQueue:
             )
 
     def pending_count(self) -> int:
-        with self._connect() as conn:
+        with self._open() as conn:
             cur = conn.execute(
                 "SELECT COUNT(*) AS c FROM mesh_forward_queue WHERE forwarded = 0"
             )

--- a/mesh/forwarding.py
+++ b/mesh/forwarding.py
@@ -1,0 +1,171 @@
+"""Store-and-forward queue + cross-node dedup for mesh propagation.
+
+This is the data model and reference algorithm behind distributed rapid alert
+propagation (#33) and mesh storm protection (#34); Phase 2's radios drive it.
+
+The model is gossip / flood-with-suppression:
+
+* Each event carries a stable ``event_id``, a ``ttl_hops`` budget, and the list
+  of ``seen_nodes`` it has passed through.
+* When a node *offers* an event (locally produced or received from a peer), the
+  queue suppresses it if this node already appears in ``seen_nodes`` (it looped)
+  or if the ``event_id`` was seen before (a duplicate arriving by another path).
+* Otherwise the node stamps itself into ``seen_nodes`` and, if ``ttl_hops`` is
+  left, enqueues a hop-decremented copy for transports to forward. Decrementing
+  TTL bounds flooding so a storm of duplicates cannot amplify across the mesh.
+
+Everything is persisted in SQLite (the platform DB) so an edge node that loses
+power resumes with its dedup memory and pending forwards intact.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, List
+
+from contracts import EmergencyEvent
+from utils import database
+
+
+@dataclass
+class OfferResult:
+    status: str        # "new" | "duplicate" | "looped"
+    will_forward: bool  # whether a hop-decremented copy was enqueued
+
+    @property
+    def accepted(self) -> bool:
+        return self.status == "new"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+class ForwardingQueue:
+    """SQLite-backed store-and-forward queue with cross-node dedup.
+
+    ``connect`` defaults to the platform DB connection but can be injected with a
+    factory pointing at a temp database for tests.
+    """
+
+    def __init__(
+        self,
+        node_id: str,
+        connect: Callable[[], sqlite3.Connection] = database.connect,
+    ) -> None:
+        self.node_id = node_id
+        self._connect = connect
+        self.init_schema()
+
+    def init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mesh_seen_events (
+                    event_id TEXT PRIMARY KEY,
+                    first_seen_utc TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mesh_forward_queue (
+                    event_id TEXT PRIMARY KEY,
+                    payload_json TEXT NOT NULL,
+                    ttl_hops INTEGER NOT NULL,
+                    enqueued_utc TEXT NOT NULL,
+                    forwarded INTEGER NOT NULL DEFAULT 0,
+                    attempts INTEGER NOT NULL DEFAULT 0
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mesh_queue_forwarded "
+                "ON mesh_forward_queue(forwarded)"
+            )
+
+    # ----- dedup memory --------------------------------------------------
+    def has_seen(self, event_id: str) -> bool:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT 1 FROM mesh_seen_events WHERE event_id = ? LIMIT 1", (event_id,)
+            )
+            return cur.fetchone() is not None
+
+    def _record_seen(self, conn: sqlite3.Connection, event_id: str) -> None:
+        conn.execute(
+            "INSERT OR IGNORE INTO mesh_seen_events (event_id, first_seen_utc) VALUES (?, ?)",
+            (event_id, _now_iso()),
+        )
+
+    # ----- core gossip logic --------------------------------------------
+    def offer(self, event: EmergencyEvent) -> OfferResult:
+        """Consider an event for forwarding; suppress loops and duplicates."""
+
+        if self.node_id in event.seen_nodes:
+            return OfferResult("looped", False)
+        if self.has_seen(event.event_id):
+            return OfferResult("duplicate", False)
+
+        event.mark_seen(self.node_id)
+        will_forward = event.ttl_hops > 0
+        with self._connect() as conn:
+            self._record_seen(conn, event.event_id)
+            if will_forward:
+                forward_copy = event.decremented()
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO mesh_forward_queue
+                        (event_id, payload_json, ttl_hops, enqueued_utc)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (
+                        forward_copy.event_id,
+                        forward_copy.to_json(),
+                        forward_copy.ttl_hops,
+                        _now_iso(),
+                    ),
+                )
+        return OfferResult("new", will_forward)
+
+    # ----- queue draining (transports call these) ------------------------
+    def pending(self, limit: int = 100) -> List[EmergencyEvent]:
+        """Return enqueued, not-yet-forwarded events (oldest first)."""
+
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT payload_json FROM mesh_forward_queue "
+                "WHERE forwarded = 0 ORDER BY enqueued_utc ASC LIMIT ?",
+                (limit,),
+            )
+            rows = cur.fetchall()
+        events: List[EmergencyEvent] = []
+        for row in rows:
+            try:
+                # Trusted local storage we wrote ourselves: decode leniently so the
+                # original trust tier/signature is preserved for relay (strict
+                # decode would clamp it as if it were untrusted inbound).
+                events.append(
+                    EmergencyEvent.from_json(row["payload_json"], strict=False)
+                )
+            except (KeyError, ValueError, json.JSONDecodeError, TypeError):
+                continue
+        return events
+
+    def mark_forwarded(self, event_id: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE mesh_forward_queue SET forwarded = 1, attempts = attempts + 1 "
+                "WHERE event_id = ?",
+                (event_id,),
+            )
+
+    def pending_count(self) -> int:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT COUNT(*) AS c FROM mesh_forward_queue WHERE forwarded = 0"
+            )
+            return int(cur.fetchone()["c"])

--- a/mesh/forwarding.py
+++ b/mesh/forwarding.py
@@ -169,12 +169,14 @@ class ForwardingQueue:
             )
             for row in cur.fetchall():
                 try:
-                    # Trusted local storage we wrote ourselves: decode leniently so
-                    # the original trust tier/signature is preserved for relay
-                    # (strict decode would clamp it as untrusted inbound).
-                    events.append(
-                        EmergencyEvent.from_json(row["payload_json"], strict=False)
-                    )
+                    # Decode leniently so the original trust tier/signature is
+                    # preserved for relay (strict decode would clamp it as
+                    # untrusted inbound), but still validate() the structure so a
+                    # corrupted/tampered on-disk row isn't forwarded as a valid
+                    # event.
+                    event = EmergencyEvent.from_json(row["payload_json"], strict=False)
+                    event.validate()
+                    events.append(event)
                 except (KeyError, ValueError, json.JSONDecodeError, TypeError):
                     bad_ids.append(row["event_id"])
             for event_id in bad_ids:

--- a/mesh/forwarding.py
+++ b/mesh/forwarding.py
@@ -129,6 +129,7 @@ class ForwardingQueue:
             return OfferResult("looped", False)
 
         now = _now_iso()
+        will_forward = event.ttl_hops > 0
         with self._open() as conn:
             try:
                 conn.execute(
@@ -137,10 +138,11 @@ class ForwardingQueue:
                 )
             except sqlite3.IntegrityError:
                 return OfferResult("duplicate", False)
-            event.mark_seen(self.node_id)
-            will_forward = event.ttl_hops > 0
             if will_forward:
+                # Stamp a COPY (not the caller's event) so a rollback can't leave
+                # this node spuriously in the original's seen_nodes.
                 forward_copy = event.decremented()
+                forward_copy.mark_seen(self.node_id)
                 conn.execute(
                     """
                     INSERT OR IGNORE INTO mesh_forward_queue
@@ -154,6 +156,8 @@ class ForwardingQueue:
                         now,
                     ),
                 )
+        # Only mutate the caller's event once the transaction has committed.
+        event.mark_seen(self.node_id)
         return OfferResult("new", will_forward)
 
     # ----- queue draining (transports call these) ------------------------

--- a/mesh/forwarding.py
+++ b/mesh/forwarding.py
@@ -28,6 +28,7 @@ from datetime import datetime, timezone
 from typing import Callable, List
 
 from contracts import EmergencyEvent
+from contracts.event import REQUIRED_ON_DECODE
 from utils import database
 
 logger = logging.getLogger(__name__)
@@ -97,9 +98,13 @@ class ForwardingQueue:
                 )
                 """
             )
+            # Composite index satisfies the hot drain query's filter AND ordering
+            # (WHERE forwarded = 0 ORDER BY enqueued_utc), avoiding a sort as the
+            # queue grows. Drop the older filter-only index it subsumes.
+            conn.execute("DROP INDEX IF EXISTS idx_mesh_queue_forwarded")
             conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_mesh_queue_forwarded "
-                "ON mesh_forward_queue(forwarded)"
+                "CREATE INDEX IF NOT EXISTS idx_mesh_queue_forwarded_enqueued "
+                "ON mesh_forward_queue(forwarded, enqueued_utc)"
             )
 
     # ----- dedup memory --------------------------------------------------
@@ -169,12 +174,18 @@ class ForwardingQueue:
             )
             for row in cur.fetchall():
                 try:
-                    # Decode leniently so the original trust tier/signature is
-                    # preserved for relay (strict decode would clamp it as
-                    # untrusted inbound), but still validate() the structure so a
-                    # corrupted/tampered on-disk row isn't forwarded as a valid
-                    # event.
-                    event = EmergencyEvent.from_json(row["payload_json"], strict=False)
+                    # Require the mesh-critical fields to be present (so a
+                    # partially corrupt row can't be minted into a "fresh"
+                    # full-TTL event and break dedup/storm protection), then decode
+                    # leniently so the original trust tier/signature is preserved
+                    # for relay (not clamped as untrusted inbound), and validate()
+                    # the structure.
+                    data = json.loads(row["payload_json"])
+                    if not isinstance(data, dict) or any(
+                        data.get(k) in (None, "") for k in REQUIRED_ON_DECODE
+                    ):
+                        raise ValueError("missing required field(s)")
+                    event = EmergencyEvent.from_dict(data, strict=False)
                     event.validate()
                     events.append(event)
                 except (KeyError, ValueError, json.JSONDecodeError, TypeError):

--- a/mesh/forwarding.py
+++ b/mesh/forwarding.py
@@ -24,7 +24,7 @@ import json
 import logging
 import sqlite3
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Callable, List
 
 from contracts import EmergencyEvent
@@ -85,6 +85,11 @@ class ForwardingQueue:
                     first_seen_utc TEXT NOT NULL
                 )
                 """
+            )
+            # Supports pruning the dedup ledger by age (see prune()).
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mesh_seen_first_seen "
+                "ON mesh_seen_events(first_seen_utc)"
             )
             conn.execute(
                 """
@@ -191,6 +196,10 @@ class ForwardingQueue:
                         raise ValueError("missing required field(s)")
                     event = EmergencyEvent.from_dict(data, strict=False)
                     event.validate()
+                    if event.event_id != row["event_id"]:
+                        # A diverging id would make mark_forwarded(event.event_id)
+                        # miss this row, wedging the queue — treat as undecodable.
+                        raise ValueError("event_id does not match queue row")
                     events.append(event)
                 except (KeyError, ValueError, json.JSONDecodeError, TypeError):
                     bad_ids.append(row["event_id"])
@@ -220,3 +229,26 @@ class ForwardingQueue:
                 "SELECT COUNT(*) AS c FROM mesh_forward_queue WHERE forwarded = 0"
             )
             return int(cur.fetchone()["c"])
+
+    def prune(self, retention_days: float = 30.0) -> int:
+        """Delete dedup-ledger entries and already-forwarded queue rows older than
+        ``retention_days``, returning the number of rows removed.
+
+        The dedup ledger (``mesh_seen_events``) otherwise grows without bound on a
+        long-lived node; hosts call this periodically to cap it. Events older than
+        the window can be re-accepted if they reappear, which is the intended
+        trade-off for bounded storage.
+        """
+
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(days=retention_days)
+        ).isoformat(timespec="seconds").replace("+00:00", "Z")
+        with self._open() as conn:
+            seen = conn.execute(
+                "DELETE FROM mesh_seen_events WHERE first_seen_utc < ?", (cutoff,)
+            ).rowcount
+            queued = conn.execute(
+                "DELETE FROM mesh_forward_queue WHERE forwarded = 1 AND enqueued_utc < ?",
+                (cutoff,),
+            ).rowcount
+        return int(seen or 0) + int(queued or 0)

--- a/mesh/node.py
+++ b/mesh/node.py
@@ -1,0 +1,73 @@
+"""Persistent node identity for the VigilantCore mesh.
+
+Every install has a stable ``node_id`` so events can record their origin and the
+path they have travelled (``origin_node_id``, ``seen_nodes``). Identity is stored
+once under the platform data dir and reused across restarts; without it, mesh
+dedup and loop-prevention have nothing to key on.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from contracts import new_ulid
+from utils.config import data_dir
+
+NODE_FILE = "node.json"
+VALID_ROLES = ("hub", "edge", "relay")
+
+
+@dataclass
+class Node:
+    node_id: str
+    label: str
+    role: str
+    created_at: str
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+def node_path(base: Optional[Path] = None) -> Path:
+    base = base or data_dir()
+    base.mkdir(parents=True, exist_ok=True)
+    return base / NODE_FILE
+
+
+def load_or_create_node(
+    *,
+    base: Optional[Path] = None,
+    label: Optional[str] = None,
+    role: str = "hub",
+) -> Node:
+    """Load this node's identity, creating and persisting it on first run."""
+
+    path = node_path(base)
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return Node(
+                node_id=str(data["node_id"]),
+                label=str(data.get("label") or data["node_id"]),
+                role=str(data.get("role") or "hub"),
+                created_at=str(data.get("created_at") or _now_iso()),
+            )
+        except Exception:
+            # Corrupt identity file: fall through and recreate.
+            pass
+    node = Node(
+        node_id=new_ulid(),
+        label=label or "vigilant-node",
+        role=role if role in VALID_ROLES else "hub",
+        created_at=_now_iso(),
+    )
+    path.write_text(json.dumps(node.as_dict(), indent=2), encoding="utf-8")
+    return node
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")

--- a/mesh/node.py
+++ b/mesh/node.py
@@ -50,14 +50,19 @@ def load_or_create_node(
     if path.exists():
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
+            loaded_role = str(data.get("role") or "hub")
             return Node(
                 node_id=str(data["node_id"]),
                 label=str(data.get("label") or data["node_id"]),
-                role=str(data.get("role") or "hub"),
+                # Validate the persisted role too, so a hand-edited/corrupted file
+                # can't leave the node with an unsupported role.
+                role=loaded_role if loaded_role in VALID_ROLES else "hub",
                 created_at=str(data.get("created_at") or _now_iso()),
             )
-        except Exception:
-            # Corrupt identity file: fall through and recreate.
+        except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+            # Corrupt/parse-failed identity file: recreate. Operational errors
+            # (e.g. permission/IO) are intentionally NOT caught here so they fail
+            # loudly instead of silently rekeying the node.
             pass
     node = Node(
         node_id=new_ulid(),
@@ -65,8 +70,17 @@ def load_or_create_node(
         role=role if role in VALID_ROLES else "hub",
         created_at=_now_iso(),
     )
-    path.write_text(json.dumps(node.as_dict(), indent=2), encoding="utf-8")
+    _atomic_write(path, json.dumps(node.as_dict(), indent=2))
     return node
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` atomically (temp file in the same dir + replace),
+    so a crash/power-loss can't leave a half-written identity file."""
+
+    tmp = path.with_name(f"{path.name}.tmp")
+    tmp.write_text(text, encoding="utf-8")
+    tmp.replace(path)
 
 
 def _now_iso() -> str:

--- a/mesh/node.py
+++ b/mesh/node.py
@@ -9,6 +9,7 @@ dedup and loop-prevention have nothing to key on.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -19,6 +20,8 @@ from utils.config import data_dir
 
 NODE_FILE = "node.json"
 VALID_ROLES = ("hub", "edge", "relay")
+# A ULID is 26 Crockford base32 chars (excludes I, L, O, U); accept either case.
+_ULID_RE = re.compile(r"^[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26}$", re.IGNORECASE)
 
 
 @dataclass
@@ -50,9 +53,13 @@ def load_or_create_node(
     if path.exists():
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
+            node_id = str(data["node_id"])
+            if not _ULID_RE.match(node_id):
+                # Corrupt/hand-edited id: recreate rather than reuse an invalid one.
+                raise ValueError(f"invalid node_id: {node_id!r}")
             loaded_role = str(data.get("role") or "hub")
             return Node(
-                node_id=str(data["node_id"]),
+                node_id=node_id,
                 label=str(data.get("label") or data["node_id"]),
                 # Validate the persisted role too, so a hand-edited/corrupted file
                 # can't leave the node with an unsupported role.

--- a/mesh/node.py
+++ b/mesh/node.py
@@ -9,7 +9,9 @@ dedup and loop-prevention have nothing to key on.
 from __future__ import annotations
 
 import json
+import os
 import re
+import tempfile
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -82,12 +84,34 @@ def load_or_create_node(
 
 
 def _atomic_write(path: Path, text: str) -> None:
-    """Write ``text`` to ``path`` atomically (temp file in the same dir + replace),
-    so a crash/power-loss can't leave a half-written identity file."""
+    """Write ``text`` to ``path`` durably and atomically.
 
-    tmp = path.with_name(f"{path.name}.tmp")
-    tmp.write_text(text, encoding="utf-8")
-    tmp.replace(path)
+    Uses a unique temp file in the same directory (so concurrent writers don't
+    clobber a shared temp path), fsyncs the file before the rename, then fsyncs
+    the directory so the rename survives power loss."""
+
+    directory = path.parent
+    fd, tmp_name = tempfile.mkstemp(dir=str(directory), prefix=f".{path.name}.", suffix=".tmp")
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        tmp.replace(path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+    # Best-effort directory fsync so the rename is durable (unsupported on some
+    # platforms, e.g. Windows).
+    try:
+        dir_fd = os.open(str(directory), os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except (OSError, AttributeError):  # pragma: no cover - platform dependent
+        pass
 
 
 def _now_iso() -> str:

--- a/tests/test_store_and_forward.py
+++ b/tests/test_store_and_forward.py
@@ -67,7 +67,10 @@ class NodeIdentityTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             base = Path(tmp)
             load_or_create_node(base=base)
-            self.assertFalse(list(base.glob("*.tmp")))
+            # Match dotfiles too: the temp file is created with a leading dot,
+            # which glob("*.tmp") would miss.
+            leftovers = [p for p in base.iterdir() if p.name.endswith(".tmp")]
+            self.assertEqual(leftovers, [])
 
 
 class StoreAndForwardTests(unittest.TestCase):

--- a/tests/test_store_and_forward.py
+++ b/tests/test_store_and_forward.py
@@ -162,6 +162,27 @@ class StoreAndForwardTests(unittest.TestCase):
             # The corrupt row is marked forwarded so it can't wedge the queue.
             self.assertEqual(queue.pending_count(), 0)
 
+    def test_prune_removes_old_dedup_entries(self) -> None:
+        import sqlite3
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "mesh.db")
+
+            def connect():
+                return sqlite3.connect(db)
+
+            queue = ForwardingQueue("NODE-A", connect=connect)
+            # An old seen-event from 2020 plus a fresh one from offer().
+            with connect() as conn:
+                conn.execute(
+                    "INSERT INTO mesh_seen_events (event_id, first_seen_utc) VALUES (?, ?)",
+                    ("OLD", "2020-01-01T00:00:00Z"),
+                )
+            queue.offer(_event(ttl=1))
+            removed = queue.prune(retention_days=30)
+            self.assertEqual(removed, 1)  # only the 2020 entry
+            self.assertFalse(queue.has_seen("OLD"))
+
     def test_pending_drops_incomplete_payload_instead_of_minting(self) -> None:
         import json
         import sqlite3

--- a/tests/test_store_and_forward.py
+++ b/tests/test_store_and_forward.py
@@ -50,6 +50,19 @@ class NodeIdentityTests(unittest.TestCase):
             )
             self.assertEqual(load_or_create_node(base=base).role, "hub")
 
+    def test_loaded_invalid_node_id_is_recreated(self) -> None:
+        import json
+        from mesh.node import node_path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            node_path(base).write_text(
+                json.dumps({"node_id": "not-a-ulid", "role": "hub"}), encoding="utf-8"
+            )
+            node = load_or_create_node(base=base)
+            self.assertNotEqual(node.node_id, "not-a-ulid")
+            self.assertEqual(len(node.node_id), 26)
+
     def test_write_is_atomic_no_tmp_left(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             base = Path(tmp)

--- a/tests/test_store_and_forward.py
+++ b/tests/test_store_and_forward.py
@@ -159,6 +159,29 @@ class StoreAndForwardTests(unittest.TestCase):
             # The corrupt row is marked forwarded so it can't wedge the queue.
             self.assertEqual(queue.pending_count(), 0)
 
+    def test_pending_drops_incomplete_payload_instead_of_minting(self) -> None:
+        import json
+        import sqlite3
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "mesh.db")
+
+            def connect():
+                return sqlite3.connect(db)
+
+            queue = ForwardingQueue("NODE-A", connect=connect)
+            # Valid JSON object but missing mesh-critical fields (ttl_hops/seen_nodes):
+            # must be dropped, not minted into a fresh full-TTL event.
+            payload = json.dumps({"title": "x", "schema_version": "2.0"})
+            with connect() as conn:
+                conn.execute(
+                    "INSERT INTO mesh_forward_queue (event_id, payload_json, ttl_hops, "
+                    "enqueued_utc) VALUES (?, ?, ?, ?)",
+                    ("PARTIAL", payload, 1, "t"),
+                )
+            self.assertEqual(queue.pending(), [])
+            self.assertEqual(queue.pending_count(), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_store_and_forward.py
+++ b/tests/test_store_and_forward.py
@@ -37,6 +37,25 @@ class NodeIdentityTests(unittest.TestCase):
             node = load_or_create_node(base=Path(tmp), role="bogus")
             self.assertEqual(node.role, "hub")
 
+    def test_loaded_invalid_role_falls_back_to_hub(self) -> None:
+        import json
+        from mesh.node import node_path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            node_path(base).write_text(
+                json.dumps({"node_id": "01J9Z3R8K2QF7M4V0WXYZ12345",
+                            "role": "bogus", "label": "x", "created_at": "t"}),
+                encoding="utf-8",
+            )
+            self.assertEqual(load_or_create_node(base=base).role, "hub")
+
+    def test_write_is_atomic_no_tmp_left(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            load_or_create_node(base=base)
+            self.assertFalse(list(base.glob("*.tmp")))
+
 
 class StoreAndForwardTests(unittest.TestCase):
     def test_offer_dedup_loop_and_ttl(self) -> None:
@@ -91,6 +110,41 @@ class StoreAndForwardTests(unittest.TestCase):
                 self.assertEqual(resumed.pending_count(), 0)
                 # Dedup memory persists even after the queue is drained.
                 self.assertTrue(resumed.has_seen(event.event_id))
+
+    def test_works_with_plain_injected_connection(self) -> None:
+        # The documented connect= seam may hand back a plain connection (tuple
+        # rows); the queue must still work via the row_factory it sets.
+        import sqlite3
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "mesh.db")
+            queue = ForwardingQueue("NODE-A", connect=lambda: sqlite3.connect(db))
+            result = queue.offer(_event(ttl=2))
+            self.assertEqual(result.status, "new")
+            self.assertEqual(len(queue.pending()), 1)
+            self.assertEqual(queue.pending_count(), 1)
+
+    def test_pending_drains_undecodable_rows(self) -> None:
+        import sqlite3
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "mesh.db")
+
+            def connect():
+                return sqlite3.connect(db)
+
+            queue = ForwardingQueue("NODE-A", connect=connect)
+            # Inject a corrupt queue row directly.
+            with connect() as conn:
+                conn.execute(
+                    "INSERT INTO mesh_forward_queue (event_id, payload_json, ttl_hops, "
+                    "enqueued_utc) VALUES (?, ?, ?, ?)",
+                    ("BADROW", "not-json", 1, "t"),
+                )
+            self.assertEqual(queue.pending_count(), 1)
+            self.assertEqual(queue.pending(), [])  # bad row decoded out
+            # The corrupt row is marked forwarded so it can't wedge the queue.
+            self.assertEqual(queue.pending_count(), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_store_and_forward.py
+++ b/tests/test_store_and_forward.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from contracts import EmergencyEvent
+from mesh.forwarding import ForwardingQueue
+from mesh.node import load_or_create_node
+from utils import database
+
+
+def _event(ttl: int = 3, severity: str = "high") -> EmergencyEvent:
+    return EmergencyEvent(
+        title="Flood warning",
+        hazard_type="flood",
+        severity=severity,
+        confidence=0.8,
+        impact_score=7,
+        ttl_hops=ttl,
+    )
+
+
+class NodeIdentityTests(unittest.TestCase):
+    def test_node_id_stable_across_loads(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            n1 = load_or_create_node(base=base, role="edge", label="field-1")
+            n2 = load_or_create_node(base=base)
+            self.assertEqual(n1.node_id, n2.node_id)
+            self.assertEqual(n1.role, "edge")
+            self.assertEqual(n1.label, "field-1")
+
+    def test_invalid_role_falls_back_to_hub(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            node = load_or_create_node(base=Path(tmp), role="bogus")
+            self.assertEqual(node.role, "hub")
+
+
+class StoreAndForwardTests(unittest.TestCase):
+    def test_offer_dedup_loop_and_ttl(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("utils.database.data_dir", return_value=Path(tmp)):
+                database.init_db()
+                queue = ForwardingQueue("NODE-A")
+
+                event = _event(ttl=3)
+                result = queue.offer(event)
+                self.assertEqual(result.status, "new")
+                self.assertTrue(result.will_forward)
+                self.assertEqual(queue.pending_count(), 1)
+
+                # Forwarded copy decremented and stamped with this node.
+                forwarded = queue.pending()[0]
+                self.assertEqual(forwarded.ttl_hops, 2)
+                self.assertIn("NODE-A", forwarded.seen_nodes)
+
+                # Duplicate by event_id is suppressed.
+                dup = _event(ttl=3)
+                dup.event_id = event.event_id
+                self.assertEqual(queue.offer(dup).status, "duplicate")
+                self.assertEqual(queue.pending_count(), 1)
+
+                # Looped event (already carries this node) is suppressed.
+                looped = _event(ttl=3)
+                looped.seen_nodes = ["NODE-A"]
+                self.assertEqual(queue.offer(looped).status, "looped")
+
+                # TTL-exhausted event is accepted but not forwarded.
+                terminal = _event(ttl=0)
+                tr = queue.offer(terminal)
+                self.assertEqual(tr.status, "new")
+                self.assertFalse(tr.will_forward)
+
+    def test_survives_restart(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("utils.database.data_dir", return_value=Path(tmp)):
+                database.init_db()
+                queue = ForwardingQueue("NODE-A")
+                event = _event(ttl=2)
+                queue.offer(event)
+                forwarded_id = queue.pending()[0].event_id
+
+                # New instance on the same DB == process restart.
+                resumed = ForwardingQueue("NODE-A")
+                self.assertTrue(resumed.has_seen(event.event_id))
+                self.assertEqual(resumed.pending_count(), 1)
+
+                resumed.mark_forwarded(forwarded_id)
+                self.assertEqual(resumed.pending_count(), 0)
+                # Dedup memory persists even after the queue is drained.
+                self.assertTrue(resumed.has_seen(event.event_id))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Phase 1 platform series — PR 3 of 4** · base: `release/0.11.0` (stacked; review/merge after PR #73)

Adds the off-grid propagation primitives: a persistent mesh node identity and a store-and-forward queue.

### Adds
- `mesh/node.py` — persistent `node_id` (ULID), label, role (`hub`/`edge`/`relay`) under the platform data dir.
- `mesh/forwarding.py` — SQLite-backed **gossip / flood-with-suppression**: duplicate `event_id`s and looped events (this node already in `seen_nodes`) suppressed; otherwise the node stamps itself and enqueues a hop-decremented copy. `ttl_hops` bounds flooding (mesh storm protection). Queue + dedup memory survive power loss.
- `tests/test_store_and_forward.py`.

### Testing
106 tests pass; ruff clean.

> Depends only on the contracts layer. Ships the model + reference algorithm; radios that drive it come in Phase 2. Advances #33/#34. Once #73 merges, retarget to `main`.