### PR TITLE
feat(plugins): plugin kernel + event bus + reference plugins (0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to VigilantCore will be documented in this file.
 
+## [0.11.0] - 2026-06-19
+
+### Added
+
+- **Plugin kernel** (`plugins/`): turns every capability into a composable plugin of one of four kinds — `SourcePlugin`, `TransportPlugin`, `DevicePlugin`, `SinkPlugin` — all speaking the `EmergencyEvent` contract and reporting health in the uniform v0.8.0 source-health shape.
+  - In-process **`EventBus`** (publish/subscribe) that supersedes the engine's single `on_new_alert` callback, with topics for new events, high-severity events, and inbound transport events.
+  - **Registry + config-driven loader** (`plugins/registry.py`, `plugins/loader.py`): declare plugins in config as `{type, name, enabled, options}`; `type` resolves to a built-in or a `module:ClassName` path. The registry stays fully inert when no plugins are configured.
+  - **Reference plugins**: an RSS source (proves the ingest seam), an MQTT transport publishing schema-valid events to `intel/events/normalized` and `intel/events/high_priority`, and a notification device.
+- **Tests** (`tests/test_plugin_registry.py`) covering bus delivery/isolation, severity-gated routing, source polling, the config loader, and MQTT validation.
+- Adds `paho-mqtt` to requirements; documents the kernel in `docs/architecture.md`.
+
 ## [0.10.0] - 2026-06-19
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Welcome to the VigilantCore documentation.
 | [Features](features.md) | Complete feature documentation |
 | [Source Discovery & Regional Coverage](source-discovery.md) | How outage/emergency/cross-region source selection works |
 | [Examples](examples.md) | Real-world usage examples |
+| [Platform Architecture](architecture.md) | Plugin kernel, event bus, and mesh node model |
 | [EmergencyEvent Schema](emergency-event-schema.md) | The canonical cross-node event contract (v2.0) |
 
 ## Quick Links

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,9 +109,11 @@ Phase 1 ships the model + reference algorithm; Phase 2's radios drive it.
 
 ## How the engine uses it
 
-`engine/monitor.py` (`MonitorEngine`) gains a platform layer that degrades
-gracefully — if an optional plugin/transport dependency is missing, monitoring
-still runs:
+A later release wires this kernel into `engine/monitor.py` (`MonitorEngine`) as a
+platform layer that degrades gracefully — if an optional plugin/transport
+dependency is missing, monitoring still runs. Until then the kernel is
+self-contained and driven directly (`build_registry(config)` +
+`registry.publish(event)`); the wiring will be:
 
 1. **Ingest** — `gather_items()` additionally pulls `registry.poll_sources()`
    and any buffered inbound transport events, feeding them through the same

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,7 +58,7 @@ Every capability is a plugin of one of four kinds (`plugins/base.py`):
 
 | Kind | Base class | Contract method | Examples |
 |------|-----------|-----------------|----------|
-| Source | `SourcePlugin` | `async poll(ctx) -> [EmergencyEvent]` | RSS, sensors, LoRa-in, MQTT-in |
+| Source | `SourcePlugin` | `async poll(ctx) -> List[EmergencyEvent]` | RSS, sensors, LoRa-in, MQTT-in |
 | Transport | `TransportPlugin` | `send(event)` (+ inbound to bus) | MQTT, LoRa/Meshtastic, BLE, satellite |
 | Device | `DevicePlugin` | `render(event)` | siren, display, GPIO relay, notification |
 | Sink | `SinkPlugin` | `handle(event)` | webhook, shell action, digest, export |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,7 +67,8 @@ Plugins communicate through an in-process **`EventBus`** (publish/subscribe),
 which replaces the engine's single `on_new_alert` callback. Topics:
 
 - `event.new` — every newly stored alert (transports + sinks subscribe).
-- `event.high` — high/critical only (devices like sirens default to this).
+- `event.high` — high-priority only: severity high/critical OR `impact_score >= 7`
+  (devices like sirens default to this).
 - `event.ingest` — inbound events from transports re-entering the pipeline.
 
 Every plugin reports health in the same shape as the v0.8.0 source-health

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,131 @@
+# VigilantCore Platform Architecture
+
+VigilantCore is evolving from a single-node event monitor into the coordinating
+**centerpiece for emergency action** — a system that monitors adverse events,
+reacts with or without internet and grid power, communicates over whatever links
+are available (LoRa/Meshtastic mesh, satellite, BLE, MQTT/LAN), informs other
+systems and responders, and uses local AI to fuse and prioritize.
+
+This document describes the **plugin kernel** that makes that possible. It was
+introduced in Phase 1 (architecture & contracts) and is the foundation every
+later capability builds on. It is fully backward compatible: with no plugins
+configured, VigilantCore behaves exactly as before.
+
+## The big picture
+
+```
+                         vigilant-core (Python hub)
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  INGEST            FUSION / AI            ROUTING            EGRESS     │
+  │  source plugins →  normalize → dedup  →   policy engine  →  transport  │
+  │  (RSS, APIs,       → impact (Ollama)  →   (urgency, geo,    + device   │
+  │   LoRa-in,           → AI fusion         channel, power)     plugins   │
+  │   sensors,         EmergencyEvent      MultiChannelRouter   (LoRa-out, │
+  │   MQTT-in)         (canonical, v2.0)   (Phase 2)            BLE, sat,   │
+  │                          │                                  MQTT, UI,  │
+  │                    SQLite store +                           siren)     │
+  │                    store-and-forward (mesh)                            │
+  └────────────┬─────────────────────────────────────────────┬───────────┘
+               │ shared EmergencyEvent contract (JSON)        │
+        ┌──────┴───────┐                              ┌────────┴────────┐
+        │ edge/ daemons │ (Rust/Go, low-power)        │ sibling apps    │
+        │ lora, mesh,   │  bridged via MQTT/stdio      │ via MQTT bus    │
+        │ satellite,    │                              │                 │
+        │ ble, power    │                              │                 │
+        └───────────────┘                              └─────────────────┘
+```
+
+## Components
+
+### The contract — `contracts/`
+
+`contracts.EmergencyEvent` is the single shape every component agrees on. It is a
+strict superset of the v1.0 normalized alert produced by
+`utils.event_normalization.normalize_event_payload`, so existing alerts upgrade
+losslessly (`EmergencyEvent.from_normalized`). New platform fields — a stable
+`event_id` (ULID), `origin_node_id`, `hazard_type`, `trust` tier, mesh
+`ttl_hops`/`seen_nodes`, and recommended `actions` — enable cross-node
+propagation, routing, and trust decisions. See
+[emergency-event-schema.md](emergency-event-schema.md).
+
+The contract is the boundary that lets the Rust/Go edge daemons (Phase 2) and
+sibling apps interoperate without sharing Python code: they exchange
+schema-valid JSON over MQTT/stdio.
+
+### The plugin kernel — `plugins/`
+
+Every capability is a plugin of one of four kinds (`plugins/base.py`):
+
+| Kind | Base class | Contract method | Examples |
+|------|-----------|-----------------|----------|
+| Source | `SourcePlugin` | `async poll(ctx) -> [EmergencyEvent]` | RSS, sensors, LoRa-in, MQTT-in |
+| Transport | `TransportPlugin` | `send(event)` (+ inbound to bus) | MQTT, LoRa/Meshtastic, BLE, satellite |
+| Device | `DevicePlugin` | `render(event)` | siren, display, GPIO relay, notification |
+| Sink | `SinkPlugin` | `handle(event)` | webhook, shell action, digest, export |
+
+Plugins communicate through an in-process **`EventBus`** (publish/subscribe),
+which replaces the engine's single `on_new_alert` callback. Topics:
+
+- `event.new` — every newly stored alert (transports + sinks subscribe).
+- `event.high` — high/critical only (devices like sirens default to this).
+- `event.ingest` — inbound events from transports re-entering the pipeline.
+
+Every plugin reports health in the same shape as the v0.8.0 source-health
+telemetry (`PluginHealth`: attempts, successes, errors, latency), so the
+dashboard can show all of them uniformly.
+
+### Lifecycle — `plugins/loader.py` + `plugins/registry.py`
+
+Plugins are declared in config (`AppConfig.plugins`) and loaded by `build_registry`:
+
+```json
+{
+  "plugins": [
+    {"type": "rss_source", "name": "county-rss", "enabled": true,
+     "options": {"feeds": ["https://example.gov/alerts.rss"]}},
+    {"type": "mqtt_transport", "name": "bus", "enabled": true,
+     "options": {"host": "127.0.0.1", "base_topic": "intel/events"}},
+    {"type": "notify_device", "name": "siren", "enabled": true, "options": {}}
+  ]
+}
+```
+
+`type` resolves to a built-in plugin or a `"module:ClassName"` path for
+out-of-tree plugins. The registry starts each plugin, wires egress plugins to bus
+topics, polls sources each cycle, and fans stored events out to egress.
+
+### Mesh node identity + store-and-forward — `mesh/`
+
+- `mesh/node.py` — a persistent `node_id` (ULID), label, and role
+  (`hub`/`edge`/`relay`) under the platform data dir, so events can record their
+  origin and travel path.
+- `mesh/forwarding.py` — a SQLite-backed store-and-forward queue implementing
+  **gossip / flood-with-suppression**: duplicate `event_id`s and looped events
+  (this node already in `seen_nodes`) are suppressed; otherwise the node stamps
+  itself and enqueues a hop-decremented copy. `ttl_hops` bounds flooding (mesh
+  storm protection). The queue survives power loss because it is persisted.
+
+Phase 1 ships the model + reference algorithm; Phase 2's radios drive it.
+
+## How the engine uses it
+
+`engine/monitor.py` (`MonitorEngine`) gains a platform layer that degrades
+gracefully — if an optional plugin/transport dependency is missing, monitoring
+still runs:
+
+1. **Ingest** — `gather_items()` additionally pulls `registry.poll_sources()`
+   and any buffered inbound transport events, feeding them through the same
+   dedup/location pipeline as native fetchers.
+2. **Egress** — when `process_items()` stores a new alert, it builds an
+   `EmergencyEvent`, offers it to the store-and-forward queue, and publishes it
+   to the bus, where transports/devices/sinks react.
+
+## Roadmap
+
+Phase 1 (this) ships contracts, the kernel, node/forwarding model, and three
+reference plugins (RSS source, MQTT transport, notify device). Later phases —
+multi-channel routing, LoRa/BLE/satellite transports + Rust/Go edge daemons,
+encrypted offline storage, LLM gateway, AI fusion, prompt-injection hardening,
+event signing — each land as plugins or additive modules against this contract.
+See the project plan and the issue tracker (#12/#19/#40, #25–#29, #33/#34, #42,
+#35, #36, #37, #39, #57–#60, #67, #70).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,7 +94,10 @@ Plugins are declared in config (`AppConfig.plugins`) and loaded by `build_regist
 out-of-tree plugins. The registry starts each plugin, wires egress plugins to bus
 topics, polls sources each cycle, and fans stored events out to egress.
 
-### Mesh node identity + store-and-forward — `mesh/`
+### Mesh node identity + store-and-forward — `mesh/` (a later release)
+
+The `mesh/` package below lands in a subsequent release; the kernel and contract
+in this release are what it builds on.
 
 - `mesh/node.py` — a persistent `node_id` (ULID), label, and role
   (`hub`/`edge`/`relay`) under the platform data dir, so events can record their
@@ -124,8 +127,9 @@ self-contained and driven directly (`build_registry(config)` +
 
 ## Roadmap
 
-Phase 1 (this) ships contracts, the kernel, node/forwarding model, and three
-reference plugins (RSS source, MQTT transport, notify device). Later phases —
+Phase 1 ships, across its releases, the contract, this plugin kernel with three
+reference plugins (RSS source, MQTT transport, notify device), and the mesh
+node/forwarding model (a later release). Subsequent phases —
 multi-channel routing, LoRa/BLE/satellite transports + Rust/Go edge daemons,
 encrypted offline storage, LLM gateway, AI fusion, prompt-injection hardening,
 event signing — each land as plugins or additive modules against this contract.

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,41 @@
+"""VigilantCore plugin kernel.
+
+Public surface: the plugin base classes and the :class:`EventBus`/registry that
+turn ingest, transport, device, and automation capabilities into composable
+plugins speaking the :class:`~contracts.EmergencyEvent` contract.
+"""
+
+from __future__ import annotations
+
+from .base import (
+    DevicePlugin,
+    EventBus,
+    Plugin,
+    PluginContext,
+    PluginHealth,
+    SinkPlugin,
+    SourcePlugin,
+    TransportPlugin,
+    TOPIC_HIGH,
+    TOPIC_INGEST,
+    TOPIC_NEW,
+)
+from .loader import BUILTIN_PLUGINS, build_registry
+from .registry import PluginRegistry
+
+__all__ = [
+    "Plugin",
+    "SourcePlugin",
+    "TransportPlugin",
+    "DevicePlugin",
+    "SinkPlugin",
+    "PluginContext",
+    "PluginHealth",
+    "EventBus",
+    "PluginRegistry",
+    "build_registry",
+    "BUILTIN_PLUGINS",
+    "TOPIC_NEW",
+    "TOPIC_HIGH",
+    "TOPIC_INGEST",
+]

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -170,7 +170,11 @@ class EventBus:
 
     def subscribe(self, topic: str, handler: Subscriber) -> None:
         with self._lock:
-            self._subs.setdefault(topic, []).append(handler)
+            handlers = self._subs.setdefault(topic, [])
+            # Idempotent: subscribing the same handler twice (e.g. a repeated
+            # subscribe_ingest on config reload) must not double-deliver.
+            if handler not in handlers:
+                handlers.append(handler)
 
     def unsubscribe(self, topic: str, handler: Subscriber) -> None:
         with self._lock:

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -1,0 +1,205 @@
+"""Plugin contracts and the in-process event bus for VigilantCore.
+
+The kernel turns every capability — fetching sources, talking to other nodes,
+driving local devices, running automations — into a plugin of one of four kinds
+that all speak the :class:`~contracts.EmergencyEvent` contract and report health
+in a single, dashboard-friendly shape (the same telemetry introduced for source
+health in v0.8.0). The :class:`EventBus` replaces the engine's single
+``on_new_alert`` callback with publish/subscribe so any number of plugins can
+react to an event without editing the engine.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+from contracts import EmergencyEvent
+
+logger = logging.getLogger(__name__)
+
+# Bus topics. Egress plugins subscribe to what they care about; the engine
+# publishes every stored alert to NEW and additionally to HIGH when severe.
+TOPIC_NEW = "event.new"          # every newly stored alert
+TOPIC_HIGH = "event.high"        # severity high/critical only
+TOPIC_INGEST = "event.ingest"    # inbound events from transports/sources -> pipeline
+
+# Plugin kinds.
+KIND_SOURCE = "source"
+KIND_TRANSPORT = "transport"
+KIND_DEVICE = "device"
+KIND_SINK = "sink"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+@dataclass
+class PluginHealth:
+    """Uniform health telemetry for every plugin (mirrors source-health v0.8.0)."""
+
+    name: str
+    kind: str
+    enabled: bool = True
+    last_attempt_utc: Optional[str] = None
+    last_success_utc: Optional[str] = None
+    last_error_utc: Optional[str] = None
+    last_error: Optional[str] = None
+    attempt_count: int = 0
+    success_count: int = 0
+    error_count: int = 0
+    last_latency_ms: Optional[float] = None
+    last_item_count: int = 0
+
+    def record_success(self, *, latency_ms: float = 0.0, item_count: int = 0) -> None:
+        now = _now_iso()
+        self.last_attempt_utc = now
+        self.last_success_utc = now
+        self.attempt_count += 1
+        self.success_count += 1
+        self.last_latency_ms = round(max(0.0, float(latency_ms)), 2)
+        self.last_item_count = max(0, int(item_count))
+        self.last_error = None
+
+    def record_error(self, message: str, *, latency_ms: float = 0.0) -> None:
+        now = _now_iso()
+        self.last_attempt_utc = now
+        self.last_error_utc = now
+        self.attempt_count += 1
+        self.error_count += 1
+        self.last_latency_ms = round(max(0.0, float(latency_ms)), 2)
+        self.last_error = (message or "error")[:240].strip() or "error"
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "enabled": self.enabled,
+            "last_attempt_utc": self.last_attempt_utc,
+            "last_success_utc": self.last_success_utc,
+            "last_error_utc": self.last_error_utc,
+            "last_error": self.last_error,
+            "attempt_count": self.attempt_count,
+            "success_count": self.success_count,
+            "error_count": self.error_count,
+            "last_latency_ms": self.last_latency_ms,
+            "last_item_count": self.last_item_count,
+        }
+
+
+Subscriber = Callable[[EmergencyEvent], None]
+
+
+class EventBus:
+    """Thread-safe, synchronous, in-process publish/subscribe for events.
+
+    Handlers are isolated: one failing subscriber never blocks the others or the
+    publisher. This is deliberately simple — the same semantics work on a Pi as
+    in tests, and durable cross-node delivery is the transports' job, not the bus'.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._subs: Dict[str, List[Subscriber]] = {}
+
+    def subscribe(self, topic: str, handler: Subscriber) -> None:
+        with self._lock:
+            self._subs.setdefault(topic, []).append(handler)
+
+    def unsubscribe(self, topic: str, handler: Subscriber) -> None:
+        with self._lock:
+            handlers = self._subs.get(topic)
+            if handlers and handler in handlers:
+                handlers.remove(handler)
+
+    def publish(self, topic: str, event: EmergencyEvent) -> int:
+        """Deliver ``event`` to every subscriber of ``topic``. Returns delivery count."""
+
+        with self._lock:
+            handlers = list(self._subs.get(topic, ()))
+        delivered = 0
+        for handler in handlers:
+            try:
+                handler(event)
+                delivered += 1
+            except Exception:  # pragma: no cover - defensive isolation
+                logger.exception("EventBus subscriber on %s failed", topic)
+        return delivered
+
+
+@dataclass
+class PluginContext:
+    """Everything a plugin needs from the host at startup."""
+
+    bus: EventBus
+    config: Any
+    node_id: Optional[str] = None
+    options: Dict[str, Any] = field(default_factory=dict)
+
+
+class Plugin(ABC):
+    """Base class for all plugins."""
+
+    kind: str = "plugin"
+
+    def __init__(self, name: str, options: Optional[Dict[str, Any]] = None) -> None:
+        self.name = name
+        self.options = options or {}
+        self.health = PluginHealth(name=name, kind=self.kind)
+
+    def start(self, ctx: PluginContext) -> None:
+        """Acquire resources and wire bus subscriptions. Override as needed."""
+
+    def stop(self) -> None:
+        """Release resources. Override as needed."""
+
+    def health_snapshot(self) -> Dict[str, Any]:
+        return self.health.as_dict()
+
+
+class SourcePlugin(Plugin):
+    """Produces events. The engine calls :meth:`poll` each cycle and ingests the
+    returned events through the normal dedup/store pipeline."""
+
+    kind = KIND_SOURCE
+
+    @abstractmethod
+    async def poll(self, ctx: PluginContext) -> List[EmergencyEvent]:
+        """Return any new events discovered this cycle (may be empty)."""
+
+
+class TransportPlugin(Plugin):
+    """Bidirectional link to other nodes/devices. Outbound via :meth:`send`
+    (the kernel subscribes it to the bus); inbound by publishing received events
+    to ``TOPIC_INGEST`` so they re-enter the pipeline."""
+
+    kind = KIND_TRANSPORT
+
+    @abstractmethod
+    def send(self, event: EmergencyEvent) -> None:
+        """Transmit an event to peers/devices over this transport."""
+
+
+class DevicePlugin(Plugin):
+    """Local output device (siren, display, GPIO relay, native notification)."""
+
+    kind = KIND_DEVICE
+
+    @abstractmethod
+    def render(self, event: EmergencyEvent) -> None:
+        """Present/actuate the event on the local device."""
+
+
+class SinkPlugin(Plugin):
+    """Side-effecting consumer (webhook, shell action, digest, export)."""
+
+    kind = KIND_SINK
+
+    @abstractmethod
+    def handle(self, event: EmergencyEvent) -> None:
+        """Process the event (fire webhook, append to digest, etc.)."""

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -23,9 +23,9 @@ from contracts import EmergencyEvent
 logger = logging.getLogger(__name__)
 
 # Bus topics. Egress plugins subscribe to what they care about; the engine
-# publishes every stored alert to NEW and additionally to HIGH when severe.
+# publishes every stored alert to NEW and additionally to HIGH when high-priority.
 TOPIC_NEW = "event.new"          # every newly stored alert
-TOPIC_HIGH = "event.high"        # severity high/critical only
+TOPIC_HIGH = "event.high"        # high-priority: severity high/critical OR impact_score >= 7
 TOPIC_INGEST = "event.ingest"    # inbound events from transports/sources -> pipeline
 
 # Plugin kinds.
@@ -80,15 +80,21 @@ class PluginHealth:
         self.success_count += 1
         self.last_latency_ms = round(max(0.0, float(latency_ms)), 2)
         self.last_item_count = max(0, int(item_count))
+        # Clear both the message and its timestamp on success (matches v0.8.0).
         self.last_error = None
+        self.last_error_utc = None
 
-    def record_error(self, message: str, *, latency_ms: float = 0.0) -> None:
+    def record_error(
+        self, message: str, *, latency_ms: float = 0.0, item_count: int = 0
+    ) -> None:
         now = _now_iso()
         self.last_attempt_utc = now
         self.last_error_utc = now
         self.attempt_count += 1
         self.error_count += 1
         self.last_latency_ms = round(max(0.0, float(latency_ms)), 2)
+        # Update item_count on every attempt, including failures (matches v0.8.0).
+        self.last_item_count = max(0, int(item_count))
         self.last_error = (message or "error")[:240].strip() or "error"
 
     def as_dict(self) -> Dict[str, Any]:
@@ -98,6 +104,8 @@ class PluginHealth:
             "enabled": self.enabled,
             "last_attempt_utc": self.last_attempt_utc,
             "last_success_utc": self.last_success_utc,
+            # Alias matching the v0.8.0 source-health dashboard key.
+            "last_successful_fetch_utc": self.last_success_utc,
             "last_error_utc": self.last_error_utc,
             "last_error": self.last_error,
             "attempt_count": self.attempt_count,

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -59,6 +59,24 @@ def coerce_bool(value: Any, default: bool = False) -> bool:
     return default
 
 
+def coerce_int(value: Any, default: int) -> int:
+    """Parse a plugin-option int, falling back to ``default`` on bad input."""
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def coerce_float(value: Any, default: float) -> float:
+    """Parse a plugin-option float, falling back to ``default`` on bad input."""
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def is_high_priority(event: EmergencyEvent) -> bool:
     """Whether an event should be routed to high-priority sinks/topics."""
 

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -34,6 +34,22 @@ KIND_TRANSPORT = "transport"
 KIND_DEVICE = "device"
 KIND_SINK = "sink"
 
+# High-priority routing criteria (issue #58): severity high/critical OR a high
+# impact score, since EmergencyEvent does not force the two to agree.
+HIGH_PRIORITY_IMPACT = 7
+_HIGH_SEVERITIES = ("high", "critical")
+
+
+def is_high_priority(event: EmergencyEvent) -> bool:
+    """Whether an event should be routed to high-priority sinks/topics."""
+
+    if str(getattr(event, "severity", "")).lower() in _HIGH_SEVERITIES:
+        return True
+    try:
+        return int(getattr(event, "impact_score", 0) or 0) >= HIGH_PRIORITY_IMPACT
+    except (TypeError, ValueError):
+        return False
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -40,6 +40,25 @@ HIGH_PRIORITY_IMPACT = 7
 _HIGH_SEVERITIES = ("high", "critical")
 
 
+def coerce_bool(value: Any, default: bool = False) -> bool:
+    """Parse a plugin-option bool, recognizing JSON string forms.
+
+    ``bool("false")`` is ``True``, a footgun for user-edited config.json, so
+    accept the usual string spellings explicitly (mirrors utils.config)."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ("1", "true", "yes", "on"):
+            return True
+        if lowered in ("0", "false", "no", "off"):
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
 def is_high_priority(event: EmergencyEvent) -> bool:
     """Whether an event should be routed to high-priority sinks/topics."""
 

--- a/plugins/builtin/__init__.py
+++ b/plugins/builtin/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in reference plugins shipped with VigilantCore."""

--- a/plugins/builtin/mqtt_transport.py
+++ b/plugins/builtin/mqtt_transport.py
@@ -3,7 +3,7 @@
 Outbound: every event is published as schema-valid JSON to
 ``<base_topic>/normalized``; high-priority events (severity high/critical OR
 ``impact_score >= 7``) additionally go to ``<base_topic>/high_priority``
-(issues #57/#58/#59, schema #60). Inbound:
+(issues #57/#58, schema #60). Inbound:
 when ``subscribe_inbound`` is set, events received on ``<base_topic>/ingest``
 are republished to the local bus' ``TOPIC_INGEST`` so they re-enter the pipeline.
 

--- a/plugins/builtin/mqtt_transport.py
+++ b/plugins/builtin/mqtt_transport.py
@@ -1,11 +1,13 @@
-"""MQTT transport plugin — publishes events to the ShelfCast-compatible bus.
+"""MQTT transport plugin — publishes events onto the event bus.
 
-Outbound: every event is published as schema-valid JSON to
+Outbound: the canonical ``EmergencyEvent`` JSON is published to
 ``<base_topic>/normalized``; high-priority events (severity high/critical OR
-``impact_score >= 7``) additionally go to ``<base_topic>/high_priority``
-(issues #57/#58, schema #60). Inbound:
-when ``subscribe_inbound`` is set, events received on ``<base_topic>/ingest``
-are republished to the local bus' ``TOPIC_INGEST`` so they re-enter the pipeline.
+``impact_score >= 7``) additionally go to ``<base_topic>/high_priority`` — the
+topic split from issues #57/#58. The payload here is the platform's own
+``EmergencyEvent`` contract; projecting it onto the exact ShelfCast wire schema
+is tracked separately in #60. Inbound: when ``subscribe_inbound`` is set, events
+received on ``<base_topic>/ingest`` are republished to the local bus'
+``TOPIC_INGEST`` so they re-enter the pipeline.
 
 ``paho-mqtt`` is imported lazily and a client can be injected via
 ``options['client']`` for tests, so importing this module never requires a broker.

--- a/plugins/builtin/mqtt_transport.py
+++ b/plugins/builtin/mqtt_transport.py
@@ -18,7 +18,7 @@ from typing import Any, Optional
 
 from contracts import EmergencyEvent
 
-from ..base import PluginContext, TransportPlugin, TOPIC_INGEST, is_high_priority
+from ..base import PluginContext, TransportPlugin, TOPIC_INGEST, coerce_bool, is_high_priority
 
 logger = logging.getLogger(__name__)
 
@@ -33,14 +33,16 @@ class MqttTransportPlugin(TransportPlugin):
         self._client = self.options.get("client")  # injectable for tests
         self._ctx: Optional[PluginContext] = None
         self._base_topic = str(self.options.get("base_topic", "intel/events")).rstrip("/")
-        self._validate = bool(self.options.get("validate", True))
+        self._validate = coerce_bool(self.options.get("validate", True), True)
 
     # ----- lifecycle -----------------------------------------------------
     def start(self, ctx: PluginContext) -> None:
         self._ctx = ctx
         if self._client is None:
             self._client = self._connect()
-        if self._client is not None and self.options.get("subscribe_inbound"):
+        if self._client is not None and coerce_bool(
+            self.options.get("subscribe_inbound", False), False
+        ):
             self._subscribe_inbound()
 
     def _connect(self):

--- a/plugins/builtin/mqtt_transport.py
+++ b/plugins/builtin/mqtt_transport.py
@@ -58,6 +58,15 @@ class MqttTransportPlugin(TransportPlugin):
         username = self.options.get("username")
         if username:
             client.username_pw_set(username, self.options.get("password"))
+        # Bounded exponential backoff so a broker outage doesn't cause a tight
+        # reconnect loop.
+        try:
+            client.reconnect_delay_set(
+                min_delay=int(self.options.get("reconnect_min_delay", 1)),
+                max_delay=int(self.options.get("reconnect_max_delay", 120)),
+            )
+        except Exception:  # pragma: no cover - older paho without the setter
+            pass
         try:
             client.connect(host, port, keepalive=int(self.options.get("keepalive", 60)))
             client.loop_start()
@@ -78,9 +87,17 @@ class MqttTransportPlugin(TransportPlugin):
             except Exception:
                 logger.exception("MQTT transport %s: bad inbound payload", self.name)
 
+        # Re-subscribe on every (re)connect: paho drops subscriptions across a
+        # broker/network drop, so a one-time subscribe would silently stop
+        # delivering inbound messages after a reconnect. *args absorbs the paho
+        # v1/v2 on_connect signature differences.
+        def _on_connect(client, _userdata, _flags, _rc, *args) -> None:
+            client.subscribe(topic)
+
         try:
             self._client.on_message = _on_message
-            self._client.subscribe(topic)
+            self._client.on_connect = _on_connect
+            self._client.subscribe(topic)  # initial subscribe; on_connect covers reconnects
         except Exception as exc:  # pragma: no cover - broker dependent
             logger.warning("MQTT transport %s inbound subscribe failed: %s", self.name, exc)
 

--- a/plugins/builtin/mqtt_transport.py
+++ b/plugins/builtin/mqtt_transport.py
@@ -70,10 +70,13 @@ class MqttTransportPlugin(TransportPlugin):
         except Exception:  # pragma: no cover - older paho without the setter
             pass
         try:
-            client.connect(host, port, keepalive=int(self.options.get("keepalive", 60)))
+            # connect_async + loop_start so an initial broker outage doesn't
+            # leave the transport permanently dead: paho keeps retrying in the
+            # background and connects once the broker is reachable.
+            client.connect_async(host, port, keepalive=int(self.options.get("keepalive", 60)))
             client.loop_start()
         except Exception as exc:
-            logger.warning("MQTT transport %s failed to connect: %s", self.name, exc)
+            logger.warning("MQTT transport %s failed to start: %s", self.name, exc)
             self.health.record_error(f"connect failed: {exc}")
             return None
         return client

--- a/plugins/builtin/mqtt_transport.py
+++ b/plugins/builtin/mqtt_transport.py
@@ -17,14 +17,13 @@ from typing import Any, Optional
 
 from contracts import EmergencyEvent
 
-from ..base import PluginContext, TransportPlugin, TOPIC_INGEST
+from ..base import PluginContext, TransportPlugin, TOPIC_INGEST, is_high_priority
 
 logger = logging.getLogger(__name__)
 
 NORMALIZED_SUFFIX = "normalized"
 HIGH_PRIORITY_SUFFIX = "high_priority"
 INGEST_SUFFIX = "ingest"
-_HIGH_SEVERITIES = {"high", "critical"}
 
 
 class MqttTransportPlugin(TransportPlugin):
@@ -93,16 +92,20 @@ class MqttTransportPlugin(TransportPlugin):
                 getattr(client, closer)()
             except Exception:
                 pass
+        # Clear the client so a later start() reconnects instead of staying inert.
+        self._client = None
 
     # ----- outbound ------------------------------------------------------
     def send(self, event: EmergencyEvent) -> None:
         if self._client is None:
-            return
+            # Configured but not connected (broker down / paho missing): surface
+            # a failure so the registry guard records it instead of faking success.
+            raise RuntimeError(f"MQTT transport {self.name} is not connected")
         if self._validate:
             event.validate()  # raises on contract violation before we publish
         payload = event.to_json()
         self._publish(f"{self._base_topic}/{NORMALIZED_SUFFIX}", payload)
-        if str(event.severity).lower() in _HIGH_SEVERITIES:
+        if is_high_priority(event):
             self._publish(f"{self._base_topic}/{HIGH_PRIORITY_SUFFIX}", payload)
 
     def _publish(self, topic: str, payload: str) -> None:
@@ -117,6 +120,6 @@ class MqttTransportPlugin(TransportPlugin):
         """Topics ``send`` would target for ``event`` (handy for tests/docs)."""
 
         topics = [f"{self._base_topic}/{NORMALIZED_SUFFIX}"]
-        if str(event.severity).lower() in _HIGH_SEVERITIES:
+        if is_high_priority(event):
             topics.append(f"{self._base_topic}/{HIGH_PRIORITY_SUFFIX}")
         return topics

--- a/plugins/builtin/mqtt_transport.py
+++ b/plugins/builtin/mqtt_transport.py
@@ -1,8 +1,9 @@
 """MQTT transport plugin — publishes events to the ShelfCast-compatible bus.
 
 Outbound: every event is published as schema-valid JSON to
-``<base_topic>/normalized``; high/critical events additionally go to
-``<base_topic>/high_priority`` (issues #57/#58/#59, schema #60). Inbound:
+``<base_topic>/normalized``; high-priority events (severity high/critical OR
+``impact_score >= 7``) additionally go to ``<base_topic>/high_priority``
+(issues #57/#58/#59, schema #60). Inbound:
 when ``subscribe_inbound`` is set, events received on ``<base_topic>/ingest``
 are republished to the local bus' ``TOPIC_INGEST`` so they re-enter the pipeline.
 

--- a/plugins/builtin/mqtt_transport.py
+++ b/plugins/builtin/mqtt_transport.py
@@ -1,0 +1,122 @@
+"""MQTT transport plugin — publishes events to the ShelfCast-compatible bus.
+
+Outbound: every event is published as schema-valid JSON to
+``<base_topic>/normalized``; high/critical events additionally go to
+``<base_topic>/high_priority`` (issues #57/#58/#59, schema #60). Inbound:
+when ``subscribe_inbound`` is set, events received on ``<base_topic>/ingest``
+are republished to the local bus' ``TOPIC_INGEST`` so they re-enter the pipeline.
+
+``paho-mqtt`` is imported lazily and a client can be injected via
+``options['client']`` for tests, so importing this module never requires a broker.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from contracts import EmergencyEvent
+
+from ..base import PluginContext, TransportPlugin, TOPIC_INGEST
+
+logger = logging.getLogger(__name__)
+
+NORMALIZED_SUFFIX = "normalized"
+HIGH_PRIORITY_SUFFIX = "high_priority"
+INGEST_SUFFIX = "ingest"
+_HIGH_SEVERITIES = {"high", "critical"}
+
+
+class MqttTransportPlugin(TransportPlugin):
+    def __init__(self, name: str, options: Optional[dict[str, Any]] = None) -> None:
+        super().__init__(name, options)
+        self._client = self.options.get("client")  # injectable for tests
+        self._ctx: Optional[PluginContext] = None
+        self._base_topic = str(self.options.get("base_topic", "intel/events")).rstrip("/")
+        self._validate = bool(self.options.get("validate", True))
+
+    # ----- lifecycle -----------------------------------------------------
+    def start(self, ctx: PluginContext) -> None:
+        self._ctx = ctx
+        if self._client is None:
+            self._client = self._connect()
+        if self._client is not None and self.options.get("subscribe_inbound"):
+            self._subscribe_inbound()
+
+    def _connect(self):
+        try:
+            import paho.mqtt.client as mqtt  # type: ignore
+        except Exception:
+            logger.warning(
+                "paho-mqtt not installed; MQTT transport %s is inert (install paho-mqtt)",
+                self.name,
+            )
+            return None
+        host = self.options.get("host", "127.0.0.1")
+        port = int(self.options.get("port", 1883))
+        client = mqtt.Client()
+        username = self.options.get("username")
+        if username:
+            client.username_pw_set(username, self.options.get("password"))
+        try:
+            client.connect(host, port, keepalive=int(self.options.get("keepalive", 60)))
+            client.loop_start()
+        except Exception as exc:
+            logger.warning("MQTT transport %s failed to connect: %s", self.name, exc)
+            self.health.record_error(f"connect failed: {exc}")
+            return None
+        return client
+
+    def _subscribe_inbound(self) -> None:
+        topic = f"{self._base_topic}/{INGEST_SUFFIX}"
+
+        def _on_message(_client, _userdata, message) -> None:
+            try:
+                event = EmergencyEvent.from_json(message.payload)
+                if self._ctx is not None:
+                    self._ctx.bus.publish(TOPIC_INGEST, event)
+            except Exception:
+                logger.exception("MQTT transport %s: bad inbound payload", self.name)
+
+        try:
+            self._client.on_message = _on_message
+            self._client.subscribe(topic)
+        except Exception as exc:  # pragma: no cover - broker dependent
+            logger.warning("MQTT transport %s inbound subscribe failed: %s", self.name, exc)
+
+    def stop(self) -> None:
+        client = self._client
+        if client is None:
+            return
+        for closer in ("loop_stop", "disconnect"):
+            try:
+                getattr(client, closer)()
+            except Exception:
+                pass
+
+    # ----- outbound ------------------------------------------------------
+    def send(self, event: EmergencyEvent) -> None:
+        if self._client is None:
+            return
+        if self._validate:
+            event.validate()  # raises on contract violation before we publish
+        payload = event.to_json()
+        self._publish(f"{self._base_topic}/{NORMALIZED_SUFFIX}", payload)
+        if str(event.severity).lower() in _HIGH_SEVERITIES:
+            self._publish(f"{self._base_topic}/{HIGH_PRIORITY_SUFFIX}", payload)
+
+    def _publish(self, topic: str, payload: str) -> None:
+        result = self._client.publish(topic, payload)
+        # paho returns an object with rc; injected fakes may return anything.
+        rc = getattr(result, "rc", 0)
+        if rc not in (0, None):
+            raise RuntimeError(f"MQTT publish to {topic} failed rc={rc}")
+        logger.debug("MQTT %s -> %s (%d bytes)", self.name, topic, len(payload))
+
+    def published_topics_for(self, event: EmergencyEvent) -> list[str]:
+        """Topics ``send`` would target for ``event`` (handy for tests/docs)."""
+
+        topics = [f"{self._base_topic}/{NORMALIZED_SUFFIX}"]
+        if str(event.severity).lower() in _HIGH_SEVERITIES:
+            topics.append(f"{self._base_topic}/{HIGH_PRIORITY_SUFFIX}")
+        return topics

--- a/plugins/builtin/mqtt_transport.py
+++ b/plugins/builtin/mqtt_transport.py
@@ -18,7 +18,14 @@ from typing import Any, Optional
 
 from contracts import EmergencyEvent
 
-from ..base import PluginContext, TransportPlugin, TOPIC_INGEST, coerce_bool, is_high_priority
+from ..base import (
+    PluginContext,
+    TransportPlugin,
+    TOPIC_INGEST,
+    coerce_bool,
+    coerce_int,
+    is_high_priority,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +62,7 @@ class MqttTransportPlugin(TransportPlugin):
             )
             return None
         host = self.options.get("host", "127.0.0.1")
-        port = int(self.options.get("port", 1883))
+        port = coerce_int(self.options.get("port", 1883), 1883)
         client = mqtt.Client()
         username = self.options.get("username")
         if username:
@@ -64,8 +71,8 @@ class MqttTransportPlugin(TransportPlugin):
         # reconnect loop.
         try:
             client.reconnect_delay_set(
-                min_delay=int(self.options.get("reconnect_min_delay", 1)),
-                max_delay=int(self.options.get("reconnect_max_delay", 120)),
+                min_delay=coerce_int(self.options.get("reconnect_min_delay", 1), 1),
+                max_delay=coerce_int(self.options.get("reconnect_max_delay", 120), 120),
             )
         except Exception:  # pragma: no cover - older paho without the setter
             pass
@@ -73,7 +80,9 @@ class MqttTransportPlugin(TransportPlugin):
             # connect_async + loop_start so an initial broker outage doesn't
             # leave the transport permanently dead: paho keeps retrying in the
             # background and connects once the broker is reachable.
-            client.connect_async(host, port, keepalive=int(self.options.get("keepalive", 60)))
+            client.connect_async(
+                host, port, keepalive=coerce_int(self.options.get("keepalive", 60), 60)
+            )
             client.loop_start()
         except Exception as exc:
             logger.warning("MQTT transport %s failed to start: %s", self.name, exc)

--- a/plugins/builtin/mqtt_transport.py
+++ b/plugins/builtin/mqtt_transport.py
@@ -146,7 +146,7 @@ class MqttTransportPlugin(TransportPlugin):
         rc = getattr(result, "rc", 0)
         if rc not in (0, None):
             raise RuntimeError(f"MQTT publish to {topic} failed rc={rc}")
-        logger.debug("MQTT %s -> %s (%d bytes)", self.name, topic, len(payload))
+        logger.debug("MQTT %s -> %s (%d chars)", self.name, topic, len(payload))
 
     def published_topics_for(self, event: EmergencyEvent) -> list[str]:
         """Topics ``send`` would target for ``event`` (handy for tests/docs)."""

--- a/plugins/builtin/mqtt_transport.py
+++ b/plugins/builtin/mqtt_transport.py
@@ -2,12 +2,12 @@
 
 Outbound: the canonical ``EmergencyEvent`` JSON is published to
 ``<base_topic>/normalized``; high-priority events (severity high/critical OR
-``impact_score >= 7``) additionally go to ``<base_topic>/high_priority`` — the
-topic split from issues #57/#58. The payload here is the platform's own
-``EmergencyEvent`` contract; projecting it onto the exact ShelfCast wire schema
-is tracked separately in #60. Inbound: when ``subscribe_inbound`` is set, events
-received on ``<base_topic>/ingest`` are republished to the local bus'
-``TOPIC_INGEST`` so they re-enter the pipeline.
+``impact_score >= 7``) additionally go to ``<base_topic>/high_priority``. The
+payload is the platform's own ``EmergencyEvent`` contract; projecting it onto the
+ShelfCast wire schema (and the related topic acceptance criteria) is tracked
+separately in #60. Inbound: when ``subscribe_inbound`` is set, events received on
+``<base_topic>/ingest`` are republished to the local bus's ``TOPIC_INGEST`` so
+they re-enter the pipeline.
 
 ``paho-mqtt`` is imported lazily and a client can be injected via
 ``options['client']`` for tests, so importing this module never requires a broker.

--- a/plugins/builtin/notify_device.py
+++ b/plugins/builtin/notify_device.py
@@ -56,12 +56,20 @@ class NotifyDevicePlugin(DevicePlugin):
                 "low": "low",
             }.get(str(event.severity).lower(), "normal")
             try:
-                subprocess.run(
+                result = subprocess.run(
                     [self._notify_send, "-u", urgency, title, body],
                     check=False,
                     timeout=5,
                 )
-                return
+                if result.returncode == 0:
+                    return
+                # Nonzero exit (e.g. headless service with no DBus session):
+                # notify-send doesn't raise, so fall through to the log instead.
+                logger.debug(
+                    "notify-send exited %s for %s; logging instead",
+                    result.returncode,
+                    self.name,
+                )
             except Exception:  # pragma: no cover - environment dependent
                 logger.debug("notify-send failed for %s; logging instead", self.name)
         logger.warning("NOTIFY %s :: %s :: %s", self.name, title, body)

--- a/plugins/builtin/notify_device.py
+++ b/plugins/builtin/notify_device.py
@@ -72,4 +72,6 @@ class NotifyDevicePlugin(DevicePlugin):
                 )
             except Exception:  # pragma: no cover - environment dependent
                 logger.debug("notify-send failed for %s; logging instead", self.name)
-        logger.warning("NOTIFY %s :: %s :: %s", self.name, title, body)
+        # INFO, not WARNING: rendering to the log is normal in headless
+        # deployments and shouldn't drown out real warnings.
+        logger.info("NOTIFY %s :: %s :: %s", self.name, title, body)

--- a/plugins/builtin/notify_device.py
+++ b/plugins/builtin/notify_device.py
@@ -17,7 +17,7 @@ from typing import List
 
 from contracts import EmergencyEvent
 
-from ..base import DevicePlugin, PluginContext
+from ..base import DevicePlugin, PluginContext, coerce_bool
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ class NotifyDevicePlugin(DevicePlugin):
     def __init__(self, name: str, options=None) -> None:
         super().__init__(name, options)
         self.rendered: List[dict] = []
-        self._use_desktop = bool(self.options.get("desktop", True))
+        self._use_desktop = coerce_bool(self.options.get("desktop", True), True)
         self._notify_send = shutil.which("notify-send") if self._use_desktop else None
 
     def start(self, ctx: PluginContext) -> None:

--- a/plugins/builtin/notify_device.py
+++ b/plugins/builtin/notify_device.py
@@ -1,0 +1,57 @@
+"""Notification device plugin — the reference DevicePlugin.
+
+By default it renders high/critical events as a local notification: it shells
+out to ``notify-send`` when available, otherwise logs a formatted line. Rendered
+events are also retained in ``self.rendered`` so tests and the dashboard can
+inspect what was surfaced without a display. Real output devices (sirens, GPIO
+relays, TTS — issue #29) follow this same ``render`` shape.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from typing import List
+
+from contracts import EmergencyEvent
+
+from ..base import DevicePlugin, PluginContext
+
+logger = logging.getLogger(__name__)
+
+
+class NotifyDevicePlugin(DevicePlugin):
+    def __init__(self, name: str, options=None) -> None:
+        super().__init__(name, options)
+        self.rendered: List[dict] = []
+        self._use_desktop = bool(self.options.get("desktop", True))
+        self._notify_send = shutil.which("notify-send") if self._use_desktop else None
+
+    def start(self, ctx: PluginContext) -> None:
+        logger.info(
+            "Notify device %s ready (desktop=%s)",
+            self.name,
+            bool(self._notify_send),
+        )
+
+    def render(self, event: EmergencyEvent) -> None:
+        title = f"[{event.severity.upper()}] {event.hazard_type}: {event.title}"
+        body_parts = [event.summary or event.predictive_outcome or ""]
+        location = (event.location or {}).get("name")
+        if location:
+            body_parts.append(f"Location: {location}")
+        body = " — ".join(p for p in body_parts if p)
+
+        self.rendered.append({"title": title, "body": body, "event_id": event.event_id})
+        if self._notify_send:
+            try:
+                subprocess.run(
+                    [self._notify_send, "-u", "critical", title, body],
+                    check=False,
+                    timeout=5,
+                )
+                return
+            except Exception:  # pragma: no cover - environment dependent
+                logger.debug("notify-send failed for %s; logging instead", self.name)
+        logger.warning("NOTIFY %s :: %s :: %s", self.name, title, body)

--- a/plugins/builtin/notify_device.py
+++ b/plugins/builtin/notify_device.py
@@ -1,7 +1,8 @@
 """Notification device plugin — the reference DevicePlugin.
 
-By default it renders high/critical events as a local notification: it shells
-out to ``notify-send`` when available, otherwise logs a formatted line. Rendered
+By default it renders high-priority events (severity high/critical OR
+``impact_score >= 7``) as a local notification: it shells out to ``notify-send``
+when available, otherwise logs a formatted line. Rendered
 events are also retained in ``self.rendered`` so tests and the dashboard can
 inspect what was surfaced without a display. Real output devices (sirens, GPIO
 relays, TTS — issue #29) follow this same ``render`` shape.

--- a/plugins/builtin/notify_device.py
+++ b/plugins/builtin/notify_device.py
@@ -46,9 +46,18 @@ class NotifyDevicePlugin(DevicePlugin):
 
         self.rendered.append({"title": title, "body": body, "event_id": event.event_id})
         if self._notify_send:
+            # Map event severity to a notify-send urgency level so a device
+            # configured to receive lower-severity events doesn't show them all
+            # as critical.
+            urgency = {
+                "critical": "critical",
+                "high": "critical",
+                "medium": "normal",
+                "low": "low",
+            }.get(str(event.severity).lower(), "normal")
             try:
                 subprocess.run(
-                    [self._notify_send, "-u", "critical", title, body],
+                    [self._notify_send, "-u", urgency, title, body],
                     check=False,
                     timeout=5,
                 )

--- a/plugins/builtin/rss_source.py
+++ b/plugins/builtin/rss_source.py
@@ -37,6 +37,10 @@ class RssSourcePlugin(SourcePlugin):
                 self.name,
                 type(raw_feeds).__name__,
             )
+            # Record the misconfiguration so health telemetry doesn't stay green.
+            self.health.record_error(
+                f"'feeds' must be a list, got {type(raw_feeds).__name__}"
+            )
             return []
         feeds = [str(f) for f in raw_feeds if f]
         if not feeds:

--- a/plugins/builtin/rss_source.py
+++ b/plugins/builtin/rss_source.py
@@ -1,0 +1,90 @@
+"""RSS source plugin — the reference SourcePlugin proving the ingest seam.
+
+This wraps plain RSS fetching as a first-class plugin: it returns
+:class:`~contracts.EmergencyEvent` objects built through the existing
+``normalize_event_payload`` adapter, so events produced here flow through the
+same dedup/store pipeline as the engine's native fetchers. New inbound
+transports (LoRa-in #25, MQTT-in #57, sensors #36) follow this exact pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from time import perf_counter
+from typing import List
+
+import feedparser
+import httpx
+
+from contracts import EmergencyEvent
+from utils.event_normalization import normalize_event_payload
+
+from ..base import PluginContext, SourcePlugin
+
+logger = logging.getLogger(__name__)
+
+
+class RssSourcePlugin(SourcePlugin):
+    """Fetch one or more RSS feeds listed in ``options['feeds']``."""
+
+    async def poll(self, ctx: PluginContext) -> List[EmergencyEvent]:
+        feeds = list(self.options.get("feeds", []) or [])
+        if not feeds:
+            return []
+        started = perf_counter()
+        events: List[EmergencyEvent] = []
+        config = ctx.config
+        location_name = getattr(config, "location_name", "") if config else ""
+        zip_code = getattr(config, "zip_code", None) if config else None
+        latitude = getattr(config, "latitude", None) if config else None
+        longitude = getattr(config, "longitude", None) if config else None
+
+        timeout = httpx.Timeout(self.options.get("timeout", 20))
+        try:
+            async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+                for feed_url in feeds:
+                    try:
+                        resp = await client.get(feed_url)
+                        resp.raise_for_status()
+                        parsed = await asyncio.to_thread(feedparser.parse, resp.text)
+                    except Exception as exc:
+                        logger.debug("RSS plugin %s: feed %s failed: %s", self.name, feed_url, exc)
+                        continue
+                    feed_title = parsed.feed.get("title", "RSS")
+                    for entry in parsed.entries:
+                        url = entry.get("link")
+                        if not url:
+                            continue
+                        title = entry.get("title", "(no title)")
+                        snippet = entry.get("summary", "")
+                        published = entry.get("published") or entry.get("updated")
+                        normalized = normalize_event_payload(
+                            source_event={"published_at": published, "source": feed_title},
+                            impact_score=5,
+                            is_relevant=True,
+                            location_name=location_name or "",
+                            source_kind="rss",
+                            zip_code=zip_code,
+                            latitude=latitude,
+                            longitude=longitude,
+                        )
+                        events.append(
+                            EmergencyEvent.from_normalized(
+                                normalized=normalized,
+                                title=title,
+                                snippet=snippet,
+                                impact_score=5,
+                                url=url,
+                                source=feed_title,
+                                source_kind="rss",
+                                origin_node_id=ctx.node_id,
+                            )
+                        )
+        except Exception as exc:  # pragma: no cover - network defensive
+            self.health.record_error(str(exc), latency_ms=(perf_counter() - started) * 1000)
+            return events
+        self.health.record_success(
+            latency_ms=(perf_counter() - started) * 1000, item_count=len(events)
+        )
+        return events

--- a/plugins/builtin/rss_source.py
+++ b/plugins/builtin/rss_source.py
@@ -20,7 +20,7 @@ import httpx
 from contracts import EmergencyEvent
 from utils.event_normalization import normalize_event_payload
 
-from ..base import PluginContext, SourcePlugin
+from ..base import PluginContext, SourcePlugin, coerce_float
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ class RssSourcePlugin(SourcePlugin):
         latitude = getattr(config, "latitude", None) if config else None
         longitude = getattr(config, "longitude", None) if config else None
 
-        timeout = httpx.Timeout(self.options.get("timeout", 20))
+        timeout = httpx.Timeout(coerce_float(self.options.get("timeout", 20), 20.0))
         feed_errors = 0
         try:
             async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:

--- a/plugins/builtin/rss_source.py
+++ b/plugins/builtin/rss_source.py
@@ -41,6 +41,7 @@ class RssSourcePlugin(SourcePlugin):
         longitude = getattr(config, "longitude", None) if config else None
 
         timeout = httpx.Timeout(self.options.get("timeout", 20))
+        feed_errors = 0
         try:
             async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
                 for feed_url in feeds:
@@ -49,6 +50,7 @@ class RssSourcePlugin(SourcePlugin):
                         resp.raise_for_status()
                         parsed = await asyncio.to_thread(feedparser.parse, resp.text)
                     except Exception as exc:
+                        feed_errors += 1
                         logger.debug("RSS plugin %s: feed %s failed: %s", self.name, feed_url, exc)
                         continue
                     feed_title = parsed.feed.get("title", "RSS")
@@ -84,7 +86,14 @@ class RssSourcePlugin(SourcePlugin):
         except Exception as exc:  # pragma: no cover - network defensive
             self.health.record_error(str(exc), latency_ms=(perf_counter() - started) * 1000)
             return events
-        self.health.record_success(
-            latency_ms=(perf_counter() - started) * 1000, item_count=len(events)
-        )
+        latency_ms = (perf_counter() - started) * 1000
+        # If every feed failed and nothing came through, that's an error, not a
+        # success — don't let the unconditional success path mask the outage.
+        if feed_errors and not events:
+            self.health.record_error(
+                f"{feed_errors} of {len(feeds)} RSS feed(s) failed",
+                latency_ms=latency_ms,
+            )
+        else:
+            self.health.record_success(latency_ms=latency_ms, item_count=len(events))
         return events

--- a/plugins/builtin/rss_source.py
+++ b/plugins/builtin/rss_source.py
@@ -49,9 +49,11 @@ class RssSourcePlugin(SourcePlugin):
         latitude = getattr(config, "latitude", None) if config else None
         longitude = getattr(config, "longitude", None) if config else None
 
-        timeout = httpx.Timeout(coerce_float(self.options.get("timeout", 20), 20.0))
         feed_errors = 0
         try:
+            # Inside the try so an invalid timeout (e.g. negative) is caught by the
+            # plugin's own error/health path rather than escaping the coroutine.
+            timeout = httpx.Timeout(coerce_float(self.options.get("timeout", 20), 20.0))
             async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
                 for feed_url in feeds:
                     try:

--- a/plugins/builtin/rss_source.py
+++ b/plugins/builtin/rss_source.py
@@ -93,7 +93,11 @@ class RssSourcePlugin(SourcePlugin):
                             )
                         )
         except Exception as exc:  # pragma: no cover - network defensive
-            self.health.record_error(str(exc), latency_ms=(perf_counter() - started) * 1000)
+            self.health.record_error(
+                str(exc),
+                latency_ms=(perf_counter() - started) * 1000,
+                item_count=len(events),
+            )
             return events
         latency_ms = (perf_counter() - started) * 1000
         # If every feed failed and nothing came through, that's an error, not a

--- a/plugins/builtin/rss_source.py
+++ b/plugins/builtin/rss_source.py
@@ -29,7 +29,16 @@ class RssSourcePlugin(SourcePlugin):
     """Fetch one or more RSS feeds listed in ``options['feeds']``."""
 
     async def poll(self, ctx: PluginContext) -> List[EmergencyEvent]:
-        feeds = list(self.options.get("feeds", []) or [])
+        raw_feeds = self.options.get("feeds", [])
+        if not isinstance(raw_feeds, list):
+            # A user-edited string would otherwise iterate character-by-character.
+            logger.warning(
+                "RSS plugin %s: 'feeds' must be a list, got %s; ignoring",
+                self.name,
+                type(raw_feeds).__name__,
+            )
+            return []
+        feeds = [str(f) for f in raw_feeds if f]
         if not feeds:
             return []
         started = perf_counter()

--- a/plugins/loader.py
+++ b/plugins/loader.py
@@ -60,7 +60,7 @@ def build_plugin(entry: dict[str, Any]) -> Optional[Plugin]:
         return None
     if not entry.get("enabled", True):
         return None
-    type_name = entry.get("type") or entry.get("name")
+    type_name = entry.get("type")
     if not type_name:
         logger.warning("Plugin entry missing 'type': %r", entry)
         return None
@@ -68,7 +68,16 @@ def build_plugin(entry: dict[str, Any]) -> Optional[Plugin]:
     if cls is None:
         return None
     name = str(entry.get("name") or type_name)
-    options = entry.get("options") or {}
+    options = entry.get("options")
+    if options is None:
+        options = {}
+    elif not isinstance(options, dict):
+        logger.warning(
+            "Plugin %s 'options' must be an object, got %s; ignoring",
+            name,
+            type(options).__name__,
+        )
+        options = {}
     try:
         return cls(name=name, options=options)
     except Exception as exc:

--- a/plugins/loader.py
+++ b/plugins/loader.py
@@ -1,0 +1,98 @@
+"""Config-driven plugin loader (plugin loader v0, issue #12).
+
+Reads the ``plugins`` list from :class:`~utils.config.AppConfig` and builds a
+started :class:`~plugins.registry.PluginRegistry`. Each entry looks like::
+
+    {"type": "rss_source", "name": "local-rss", "enabled": true,
+     "options": {"feeds": ["https://…/rss"]}}
+
+``type`` resolves against the built-in catalog, or as a ``"module:ClassName"``
+path for out-of-tree plugins — the groundwork for the richer Plugin API (#19/#40).
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import Any, List, Optional, Type
+
+from .base import Plugin
+from .builtin.mqtt_transport import MqttTransportPlugin
+from .builtin.notify_device import NotifyDevicePlugin
+from .builtin.rss_source import RssSourcePlugin
+from .registry import PluginRegistry
+
+logger = logging.getLogger(__name__)
+
+# Built-in plugin catalog: type string -> class.
+BUILTIN_PLUGINS: dict[str, Type[Plugin]] = {
+    "rss_source": RssSourcePlugin,
+    "mqtt_transport": MqttTransportPlugin,
+    "notify_device": NotifyDevicePlugin,
+}
+
+
+def resolve_plugin_class(type_name: str) -> Optional[Type[Plugin]]:
+    """Resolve a plugin ``type`` to a class, by catalog name or ``module:Class``."""
+
+    if type_name in BUILTIN_PLUGINS:
+        return BUILTIN_PLUGINS[type_name]
+    if ":" in type_name:
+        module_path, _, class_name = type_name.partition(":")
+        try:
+            module = importlib.import_module(module_path)
+            cls = getattr(module, class_name)
+        except Exception as exc:
+            logger.warning("Could not import plugin %s: %s", type_name, exc)
+            return None
+        if isinstance(cls, type) and issubclass(cls, Plugin):
+            return cls
+        logger.warning("Plugin %s is not a Plugin subclass", type_name)
+        return None
+    logger.warning("Unknown plugin type %r", type_name)
+    return None
+
+
+def build_plugin(entry: dict[str, Any]) -> Optional[Plugin]:
+    """Instantiate a single plugin from a config entry, or ``None`` if disabled/invalid."""
+
+    if not isinstance(entry, dict):
+        return None
+    if not entry.get("enabled", True):
+        return None
+    type_name = entry.get("type") or entry.get("name")
+    if not type_name:
+        logger.warning("Plugin entry missing 'type': %r", entry)
+        return None
+    cls = resolve_plugin_class(str(type_name))
+    if cls is None:
+        return None
+    name = str(entry.get("name") or type_name)
+    options = entry.get("options") or {}
+    try:
+        return cls(name=name, options=options)
+    except Exception as exc:
+        logger.warning("Failed to instantiate plugin %s: %s", name, exc)
+        return None
+
+
+def build_registry(
+    config: Any = None,
+    node_id: Optional[str] = None,
+    *,
+    start: bool = True,
+) -> PluginRegistry:
+    """Build (and by default start) a registry from ``config.plugins``."""
+
+    registry = PluginRegistry(config=config, node_id=node_id)
+    entries: List[dict[str, Any]] = []
+    if config is not None:
+        entries = list(getattr(config, "plugins", None) or [])
+    for entry in entries:
+        plugin = build_plugin(entry)
+        if plugin is not None:
+            registry.register(plugin)
+            logger.info("Loaded plugin %s (%s)", plugin.name, plugin.kind)
+    if start:
+        registry.start_all()
+    return registry

--- a/plugins/loader.py
+++ b/plugins/loader.py
@@ -16,7 +16,7 @@ import importlib
 import logging
 from typing import Any, List, Optional, Type
 
-from .base import Plugin
+from .base import Plugin, coerce_bool
 from .builtin.mqtt_transport import MqttTransportPlugin
 from .builtin.notify_device import NotifyDevicePlugin
 from .builtin.rss_source import RssSourcePlugin
@@ -58,7 +58,7 @@ def build_plugin(entry: dict[str, Any]) -> Optional[Plugin]:
 
     if not isinstance(entry, dict):
         return None
-    if not entry.get("enabled", True):
+    if not coerce_bool(entry.get("enabled", True), True):
         return None
     type_name = entry.get("type")
     if not type_name:

--- a/plugins/loader.py
+++ b/plugins/loader.py
@@ -96,7 +96,16 @@ def build_registry(
     registry = PluginRegistry(config=config, node_id=node_id)
     entries: List[dict[str, Any]] = []
     if config is not None:
-        entries = list(getattr(config, "plugins", None) or [])
+        raw = getattr(config, "plugins", None)
+        if raw is None:
+            raw = []
+        elif not isinstance(raw, list):
+            logger.warning(
+                "config.plugins must be a list, got %s; ignoring",
+                type(raw).__name__,
+            )
+            raw = []
+        entries = raw
     for entry in entries:
         plugin = build_plugin(entry)
         if plugin is not None:

--- a/plugins/registry.py
+++ b/plugins/registry.py
@@ -88,8 +88,9 @@ class PluginRegistry:
         elif isinstance(plugin, DevicePlugin):
             # Devices (sirens/displays) default to high-priority only (severity
             # high/critical OR impact_score >= 7); override with options
-            # {"min_severity": "low"} to receive everything.
-            topic = TOPIC_NEW if plugin.options.get("min_severity") == "low" else TOPIC_HIGH
+            # {"min_severity": "low"} to receive everything (case-insensitive).
+            min_severity = str(plugin.options.get("min_severity", "")).strip().lower()
+            topic = TOPIC_NEW if min_severity == "low" else TOPIC_HIGH
             self._subscribe_egress(topic, self._guard(plugin, plugin.render))
         elif isinstance(plugin, SinkPlugin):
             self._subscribe_egress(TOPIC_NEW, self._guard(plugin, plugin.handle))

--- a/plugins/registry.py
+++ b/plugins/registry.py
@@ -47,6 +47,15 @@ class PluginRegistry:
     # ----- registration / lifecycle -------------------------------------
     def register(self, plugin: Plugin) -> None:
         self._plugins.append(plugin)
+        # If the registry is already running, start and wire the late arrival now
+        # so egress plugins actually receive events.
+        if self._started:
+            try:
+                plugin.start(self._context_for(plugin))
+                self._wire_egress(plugin)
+            except Exception as exc:
+                logger.exception("Failed to start plugin %s", plugin.name)
+                plugin.health.record_error(f"start failed: {exc}")
 
     @property
     def plugins(self) -> List[Plugin]:

--- a/plugins/registry.py
+++ b/plugins/registry.py
@@ -27,11 +27,10 @@ from .base import (
     TOPIC_HIGH,
     TOPIC_INGEST,
     TOPIC_NEW,
+    is_high_priority,
 )
 
 logger = logging.getLogger(__name__)
-
-_HIGH_SEVERITIES = {"high", "critical"}
 
 
 class PluginRegistry:
@@ -135,10 +134,12 @@ class PluginRegistry:
         events: List[EmergencyEvent] = []
         for plugin, result in zip(source_plugins, results):
             if isinstance(result, Exception):
+                # Only record here for an *uncaught* error; a plugin's own poll()
+                # (e.g. RssSourcePlugin) records its success/error itself, so we do
+                # not double-count the success path.
                 logger.warning("Source plugin %s poll failed: %s", plugin.name, result)
                 plugin.health.record_error(str(result))
                 continue
-            plugin.health.record_success(item_count=len(result))
             events.extend(result)
         return events
 
@@ -148,7 +149,7 @@ class PluginRegistry:
         if not self._plugins:
             return
         self.bus.publish(TOPIC_NEW, event)
-        if str(event.severity).lower() in _HIGH_SEVERITIES:
+        if is_high_priority(event):
             self.bus.publish(TOPIC_HIGH, event)
 
     def subscribe_ingest(self, handler: Callable[[EmergencyEvent], None]) -> None:

--- a/plugins/registry.py
+++ b/plugins/registry.py
@@ -70,9 +70,9 @@ class PluginRegistry:
             try:
                 plugin.start(self._context_for(plugin))
                 self._wire_egress(plugin)
-            except Exception:
+            except Exception as exc:
                 logger.exception("Failed to start plugin %s", plugin.name)
-                plugin.health.record_error("start failed")
+                plugin.health.record_error(f"start failed: {exc}")
         self._started = True
 
     def _subscribe_egress(self, topic: str, handler: Callable[[EmergencyEvent], None]) -> None:
@@ -140,6 +140,18 @@ class PluginRegistry:
                 # not double-count the success path.
                 logger.warning("Source plugin %s poll failed: %s", plugin.name, result)
                 plugin.health.record_error(str(result))
+                continue
+            if not isinstance(result, list):
+                # A misbehaving plugin (returns None or a single event) must not
+                # abort polling for the others — keep the isolation guarantee.
+                logger.warning(
+                    "Source plugin %s returned %s, expected list; skipping",
+                    plugin.name,
+                    type(result).__name__,
+                )
+                plugin.health.record_error(
+                    f"poll returned {type(result).__name__}, expected list"
+                )
                 continue
             events.extend(result)
         return events

--- a/plugins/registry.py
+++ b/plugins/registry.py
@@ -1,0 +1,149 @@
+"""Plugin lifecycle + event routing registry.
+
+The registry owns the :class:`EventBus`, starts/stops plugins, wires egress
+plugins (transport/device/sink) to the bus topics they care about, and gives the
+engine two integration points: :meth:`poll_sources` (pull new events from source
+plugins each cycle) and :meth:`publish` (fan a stored event out to all egress
+plugins). It is intentionally inert when no plugins are configured, so default
+installs behave exactly as before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+from contracts import EmergencyEvent
+
+from .base import (
+    DevicePlugin,
+    EventBus,
+    Plugin,
+    PluginContext,
+    SinkPlugin,
+    SourcePlugin,
+    TransportPlugin,
+    TOPIC_HIGH,
+    TOPIC_INGEST,
+    TOPIC_NEW,
+)
+
+logger = logging.getLogger(__name__)
+
+_HIGH_SEVERITIES = {"high", "critical"}
+
+
+class PluginRegistry:
+    def __init__(self, config: Any = None, node_id: Optional[str] = None) -> None:
+        self.config = config
+        self.node_id = node_id
+        self.bus = EventBus()
+        self._plugins: List[Plugin] = []
+        self._started = False
+
+    # ----- registration / lifecycle -------------------------------------
+    def register(self, plugin: Plugin) -> None:
+        self._plugins.append(plugin)
+
+    @property
+    def plugins(self) -> List[Plugin]:
+        return list(self._plugins)
+
+    def sources(self) -> List[SourcePlugin]:
+        return [p for p in self._plugins if isinstance(p, SourcePlugin)]
+
+    def _context_for(self, plugin: Plugin) -> PluginContext:
+        return PluginContext(
+            bus=self.bus,
+            config=self.config,
+            node_id=self.node_id,
+            options=plugin.options,
+        )
+
+    def start_all(self) -> None:
+        if self._started:
+            return
+        for plugin in self._plugins:
+            try:
+                plugin.start(self._context_for(plugin))
+                self._wire_egress(plugin)
+            except Exception:
+                logger.exception("Failed to start plugin %s", plugin.name)
+                plugin.health.record_error("start failed")
+        self._started = True
+
+    def _wire_egress(self, plugin: Plugin) -> None:
+        """Subscribe egress plugins to the appropriate bus topics."""
+
+        if isinstance(plugin, TransportPlugin):
+            # Transports get every event; they decide normal vs high internally.
+            self.bus.subscribe(TOPIC_NEW, self._guard(plugin, plugin.send))
+        elif isinstance(plugin, DevicePlugin):
+            # Devices (sirens/displays) default to high-severity only; override
+            # with options {"min_severity": "low"} to receive everything.
+            topic = TOPIC_NEW if plugin.options.get("min_severity") == "low" else TOPIC_HIGH
+            self.bus.subscribe(topic, self._guard(plugin, plugin.render))
+        elif isinstance(plugin, SinkPlugin):
+            self.bus.subscribe(TOPIC_NEW, self._guard(plugin, plugin.handle))
+
+    def _guard(self, plugin: Plugin, fn: Callable[[EmergencyEvent], None]):
+        """Wrap an egress handler so it records health and never raises into the bus."""
+
+        def _handler(event: EmergencyEvent) -> None:
+            try:
+                fn(event)
+                plugin.health.record_success(item_count=1)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.exception("Plugin %s handler failed", plugin.name)
+                plugin.health.record_error(str(exc))
+
+        return _handler
+
+    def stop_all(self) -> None:
+        for plugin in self._plugins:
+            try:
+                plugin.stop()
+            except Exception:
+                logger.exception("Failed to stop plugin %s", plugin.name)
+        self._started = False
+
+    # ----- engine integration -------------------------------------------
+    async def poll_sources(self) -> List[EmergencyEvent]:
+        """Collect new events from all source plugins concurrently."""
+
+        source_plugins = self.sources()
+        if not source_plugins:
+            return []
+        ctx_map = {p: self._context_for(p) for p in source_plugins}
+        results = await asyncio.gather(
+            *[p.poll(ctx_map[p]) for p in source_plugins],
+            return_exceptions=True,
+        )
+        events: List[EmergencyEvent] = []
+        for plugin, result in zip(source_plugins, results):
+            if isinstance(result, Exception):
+                logger.warning("Source plugin %s poll failed: %s", plugin.name, result)
+                plugin.health.record_error(str(result))
+                continue
+            plugin.health.record_success(item_count=len(result))
+            events.extend(result)
+        return events
+
+    def publish(self, event: EmergencyEvent) -> None:
+        """Fan a stored event out to egress plugins (NEW, plus HIGH when severe)."""
+
+        if not self._plugins:
+            return
+        self.bus.publish(TOPIC_NEW, event)
+        if str(event.severity).lower() in _HIGH_SEVERITIES:
+            self.bus.publish(TOPIC_HIGH, event)
+
+    def subscribe_ingest(self, handler: Callable[[EmergencyEvent], None]) -> None:
+        """Register the engine's handler for inbound events from transports."""
+
+        self.bus.subscribe(TOPIC_INGEST, handler)
+
+    # ----- introspection -------------------------------------------------
+    def health(self) -> List[Dict[str, Any]]:
+        return [p.health_snapshot() for p in self._plugins]

--- a/plugins/registry.py
+++ b/plugins/registry.py
@@ -41,6 +41,9 @@ class PluginRegistry:
         self.bus = EventBus()
         self._plugins: List[Plugin] = []
         self._started = False
+        # (topic, handler) pairs wired in _wire_egress, so stop_all can remove
+        # them and a subsequent start_all doesn't double-subscribe.
+        self._egress_subs: List[tuple[str, Callable[[EmergencyEvent], None]]] = []
 
     # ----- registration / lifecycle -------------------------------------
     def register(self, plugin: Plugin) -> None:
@@ -73,19 +76,23 @@ class PluginRegistry:
                 plugin.health.record_error("start failed")
         self._started = True
 
+    def _subscribe_egress(self, topic: str, handler: Callable[[EmergencyEvent], None]) -> None:
+        self.bus.subscribe(topic, handler)
+        self._egress_subs.append((topic, handler))
+
     def _wire_egress(self, plugin: Plugin) -> None:
         """Subscribe egress plugins to the appropriate bus topics."""
 
         if isinstance(plugin, TransportPlugin):
             # Transports get every event; they decide normal vs high internally.
-            self.bus.subscribe(TOPIC_NEW, self._guard(plugin, plugin.send))
+            self._subscribe_egress(TOPIC_NEW, self._guard(plugin, plugin.send))
         elif isinstance(plugin, DevicePlugin):
             # Devices (sirens/displays) default to high-severity only; override
             # with options {"min_severity": "low"} to receive everything.
             topic = TOPIC_NEW if plugin.options.get("min_severity") == "low" else TOPIC_HIGH
-            self.bus.subscribe(topic, self._guard(plugin, plugin.render))
+            self._subscribe_egress(topic, self._guard(plugin, plugin.render))
         elif isinstance(plugin, SinkPlugin):
-            self.bus.subscribe(TOPIC_NEW, self._guard(plugin, plugin.handle))
+            self._subscribe_egress(TOPIC_NEW, self._guard(plugin, plugin.handle))
 
     def _guard(self, plugin: Plugin, fn: Callable[[EmergencyEvent], None]):
         """Wrap an egress handler so it records health and never raises into the bus."""
@@ -106,6 +113,11 @@ class PluginRegistry:
                 plugin.stop()
             except Exception:
                 logger.exception("Failed to stop plugin %s", plugin.name)
+        # Remove egress subscriptions so a later start_all() re-wires cleanly
+        # instead of double-delivering events to every plugin.
+        for topic, handler in self._egress_subs:
+            self.bus.unsubscribe(topic, handler)
+        self._egress_subs.clear()
         self._started = False
 
     # ----- engine integration -------------------------------------------

--- a/plugins/registry.py
+++ b/plugins/registry.py
@@ -50,12 +50,22 @@ class PluginRegistry:
         # If the registry is already running, start and wire the late arrival now
         # so egress plugins actually receive events.
         if self._started:
-            try:
-                plugin.start(self._context_for(plugin))
-                self._wire_egress(plugin)
-            except Exception as exc:
-                logger.exception("Failed to start plugin %s", plugin.name)
-                plugin.health.record_error(f"start failed: {exc}")
+            self._start_and_wire(plugin)
+
+    def _start_and_wire(self, plugin: Plugin) -> None:
+        """Start a plugin then wire its egress, recording which step failed."""
+
+        try:
+            plugin.start(self._context_for(plugin))
+        except Exception as exc:
+            logger.exception("Failed to start plugin %s", plugin.name)
+            plugin.health.record_error(f"start failed: {exc}")
+            return
+        try:
+            self._wire_egress(plugin)
+        except Exception as exc:
+            logger.exception("Failed to wire plugin %s", plugin.name)
+            plugin.health.record_error(f"wiring failed: {exc}")
 
     @property
     def plugins(self) -> List[Plugin]:
@@ -76,12 +86,7 @@ class PluginRegistry:
         if self._started:
             return
         for plugin in self._plugins:
-            try:
-                plugin.start(self._context_for(plugin))
-                self._wire_egress(plugin)
-            except Exception as exc:
-                logger.exception("Failed to start plugin %s", plugin.name)
-                plugin.health.record_error(f"start failed: {exc}")
+            self._start_and_wire(plugin)
         self._started = True
 
     def _subscribe_egress(self, topic: str, handler: Callable[[EmergencyEvent], None]) -> None:

--- a/plugins/registry.py
+++ b/plugins/registry.py
@@ -86,8 +86,9 @@ class PluginRegistry:
             # Transports get every event; they decide normal vs high internally.
             self._subscribe_egress(TOPIC_NEW, self._guard(plugin, plugin.send))
         elif isinstance(plugin, DevicePlugin):
-            # Devices (sirens/displays) default to high-severity only; override
-            # with options {"min_severity": "low"} to receive everything.
+            # Devices (sirens/displays) default to high-priority only (severity
+            # high/critical OR impact_score >= 7); override with options
+            # {"min_severity": "low"} to receive everything.
             topic = TOPIC_NEW if plugin.options.get("min_severity") == "low" else TOPIC_HIGH
             self._subscribe_egress(topic, self._guard(plugin, plugin.render))
         elif isinstance(plugin, SinkPlugin):
@@ -144,7 +145,8 @@ class PluginRegistry:
         return events
 
     def publish(self, event: EmergencyEvent) -> None:
-        """Fan a stored event out to egress plugins (NEW, plus HIGH when severe)."""
+        """Fan a stored event out to egress plugins (NEW, plus HIGH when the event
+        is high-priority: severity high/critical OR impact_score >= 7)."""
 
         if not self._plugins:
             return

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ flask
 beautifulsoup4
 psutil
 jsonschema
+paho-mqtt

--- a/src/main.py
+++ b/src/main.py
@@ -666,7 +666,11 @@ class MainWindow(QtWidgets.QMainWindow):
         dialog.polling_input.setText(str(self.config.polling_minutes))
         dialog.insight_refresh_combo.setCurrentText(str(self.config.insight_refresh_minutes or 5))
         if dialog.exec() == QtWidgets.QDialog.Accepted:
-            self.config = dialog.to_config()
+            new_config = dialog.to_config()
+            # The dialog doesn't expose the plugin list; carry it over so saving
+            # settings doesn't wipe a user's configured plugins.
+            new_config.plugins = self.config.plugins
+            self.config = new_config
             save_config(self.config)
             self.stop_monitoring()
             self.refresh_feed()

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from contracts import EmergencyEvent
+from plugins import EventBus, TOPIC_INGEST, TOPIC_NEW, build_registry
+from plugins.base import PluginContext, SourcePlugin
+from plugins.builtin.mqtt_transport import MqttTransportPlugin
+from plugins.builtin.notify_device import NotifyDevicePlugin
+from plugins.loader import build_plugin, resolve_plugin_class
+
+
+class FakeMqttClient:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, str]] = []
+
+    def publish(self, topic, payload):
+        self.published.append((topic, payload))
+        return type("R", (), {"rc": 0})()
+
+
+class _Cfg:
+    """Minimal config-like object exposing a plugins list."""
+
+    def __init__(self, plugins):
+        self.plugins = plugins
+        self.location_name = "Test County"
+        self.zip_code = None
+        self.latitude = None
+        self.longitude = None
+
+
+def _event(severity: str = "high") -> EmergencyEvent:
+    return EmergencyEvent(
+        title="Test hazard",
+        hazard_type="storm",
+        severity=severity,
+        confidence=0.7,
+        impact_score=8 if severity in ("high", "critical") else 3,
+    )
+
+
+class EventBusTests(unittest.TestCase):
+    def test_publish_delivers_to_subscribers(self) -> None:
+        bus = EventBus()
+        received = []
+        bus.subscribe(TOPIC_NEW, received.append)
+        delivered = bus.publish(TOPIC_NEW, _event())
+        self.assertEqual(delivered, 1)
+        self.assertEqual(len(received), 1)
+
+    def test_failing_subscriber_is_isolated(self) -> None:
+        bus = EventBus()
+        ok = []
+
+        def boom(_event):
+            raise RuntimeError("kaboom")
+
+        bus.subscribe(TOPIC_NEW, boom)
+        bus.subscribe(TOPIC_NEW, ok.append)
+        bus.publish(TOPIC_NEW, _event())  # must not raise
+        self.assertEqual(len(ok), 1)
+
+    def test_unsubscribe(self) -> None:
+        bus = EventBus()
+        received = []
+        bus.subscribe(TOPIC_NEW, received.append)
+        bus.unsubscribe(TOPIC_NEW, received.append)
+        bus.publish(TOPIC_NEW, _event())
+        self.assertEqual(received, [])
+
+
+class RegistryRoutingTests(unittest.TestCase):
+    def test_high_severity_routes_to_device_and_transport(self) -> None:
+        fake = FakeMqttClient()
+        cfg = _Cfg([
+            {"type": "mqtt_transport", "name": "bus",
+             "options": {"client": fake, "base_topic": "intel/events"}},
+            {"type": "notify_device", "name": "siren",
+             "options": {"desktop": False}},
+        ])
+        registry = build_registry(cfg, node_id="NODE-A")
+        registry.publish(_event("critical"))
+
+        topics = [t for t, _ in fake.published]
+        self.assertIn("intel/events/normalized", topics)
+        self.assertIn("intel/events/high_priority", topics)
+        siren = next(p for p in registry.plugins if p.name == "siren")
+        self.assertEqual(len(siren.rendered), 1)
+
+    def test_low_severity_skips_default_device_and_high_topic(self) -> None:
+        fake = FakeMqttClient()
+        cfg = _Cfg([
+            {"type": "mqtt_transport", "name": "bus",
+             "options": {"client": fake, "base_topic": "intel/events"}},
+            {"type": "notify_device", "name": "siren",
+             "options": {"desktop": False}},
+        ])
+        registry = build_registry(cfg, node_id="NODE-A")
+        registry.publish(_event("low"))
+
+        topics = [t for t, _ in fake.published]
+        self.assertEqual(topics, ["intel/events/normalized"])  # no high_priority
+        siren = next(p for p in registry.plugins if p.name == "siren")
+        self.assertEqual(siren.rendered, [])  # device defaults to high only
+
+    def test_device_min_severity_low_receives_all(self) -> None:
+        cfg = _Cfg([
+            {"type": "notify_device", "name": "log",
+             "options": {"min_severity": "low", "desktop": False}},
+        ])
+        registry = build_registry(cfg, node_id="NODE-A")
+        registry.publish(_event("low"))
+        log = registry.plugins[0]
+        self.assertEqual(len(log.rendered), 1)
+
+    def test_disabled_plugin_not_loaded(self) -> None:
+        cfg = _Cfg([
+            {"type": "notify_device", "name": "off", "enabled": False, "options": {}},
+        ])
+        registry = build_registry(cfg, node_id="NODE-A")
+        self.assertEqual(registry.plugins, [])
+
+    def test_inert_registry_with_no_plugins(self) -> None:
+        registry = build_registry(_Cfg([]), node_id="NODE-A")
+        # publish must be a no-op and never raise.
+        registry.publish(_event("critical"))
+        self.assertEqual(registry.health(), [])
+
+
+class SourcePluginPollTests(unittest.TestCase):
+    def test_poll_sources_collects_events(self) -> None:
+        class StubSource(SourcePlugin):
+            async def poll(self, ctx: PluginContext):
+                return [_event("medium"), _event("medium")]
+
+        registry = build_registry(_Cfg([]), node_id="NODE-A")
+        registry.register(StubSource("stub"))
+        events = asyncio.run(registry.poll_sources())
+        self.assertEqual(len(events), 2)
+
+    def test_poll_sources_isolates_failures(self) -> None:
+        class BadSource(SourcePlugin):
+            async def poll(self, ctx: PluginContext):
+                raise RuntimeError("nope")
+
+        class GoodSource(SourcePlugin):
+            async def poll(self, ctx: PluginContext):
+                return [_event("low")]
+
+        registry = build_registry(_Cfg([]), node_id="NODE-A")
+        registry.register(BadSource("bad"))
+        registry.register(GoodSource("good"))
+        events = asyncio.run(registry.poll_sources())
+        self.assertEqual(len(events), 1)
+
+
+class IngestSubscriptionTests(unittest.TestCase):
+    def test_inbound_events_reach_subscriber(self) -> None:
+        registry = build_registry(_Cfg([]), node_id="NODE-A")
+        got = []
+        registry.subscribe_ingest(got.append)
+        registry.bus.publish(TOPIC_INGEST, _event())
+        self.assertEqual(len(got), 1)
+
+
+class LoaderTests(unittest.TestCase):
+    def test_resolve_builtin_and_module_path(self) -> None:
+        self.assertIs(resolve_plugin_class("notify_device"), NotifyDevicePlugin)
+        cls = resolve_plugin_class(
+            "plugins.builtin.mqtt_transport:MqttTransportPlugin"
+        )
+        self.assertIs(cls, MqttTransportPlugin)
+        self.assertIsNone(resolve_plugin_class("does_not_exist"))
+
+    def test_build_plugin_respects_enabled(self) -> None:
+        self.assertIsNone(build_plugin({"type": "notify_device", "enabled": False}))
+        plugin = build_plugin({"type": "notify_device", "name": "n"})
+        self.assertIsInstance(plugin, NotifyDevicePlugin)
+
+
+class MqttTransportTests(unittest.TestCase):
+    def test_validate_before_publish(self) -> None:
+        fake = FakeMqttClient()
+        plugin = MqttTransportPlugin("bus", {"client": fake, "base_topic": "intel/events"})
+        plugin.start(PluginContext(bus=EventBus(), config=None, node_id="N"))
+        # An invalid event must be rejected before any publish happens.
+        bad = EmergencyEvent(title="x", severity="not-real")
+        with self.assertRaises(ValueError):
+            plugin.send(bad)
+        self.assertEqual(fake.published, [])
+
+    def test_published_topics_for(self) -> None:
+        plugin = MqttTransportPlugin("bus", {"base_topic": "intel/events"})
+        self.assertEqual(
+            plugin.published_topics_for(_event("low")),
+            ["intel/events/normalized"],
+        )
+        self.assertEqual(
+            plugin.published_topics_for(_event("critical")),
+            ["intel/events/normalized", "intel/events/high_priority"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -115,6 +115,23 @@ class RegistryRoutingTests(unittest.TestCase):
         log = registry.plugins[0]
         self.assertEqual(len(log.rendered), 1)
 
+    def test_high_impact_score_routes_high_even_if_severity_low(self) -> None:
+        # issue #58: high_priority is impact_score >= 7 OR severity high/critical.
+        fake = FakeMqttClient()
+        cfg = _Cfg([
+            {"type": "mqtt_transport", "name": "bus",
+             "options": {"client": fake, "base_topic": "intel/events"}},
+            {"type": "notify_device", "name": "siren",
+             "options": {"desktop": False}},
+        ])
+        registry = build_registry(cfg, node_id="NODE-A")
+        ev = EmergencyEvent(title="Quiet-looking but severe", hazard_type="outage",
+                            severity="medium", confidence=0.6, impact_score=8)
+        registry.publish(ev)
+        self.assertIn("intel/events/high_priority", [t for t, _ in fake.published])
+        siren = next(p for p in registry.plugins if p.name == "siren")
+        self.assertEqual(len(siren.rendered), 1)
+
     def test_disabled_plugin_not_loaded(self) -> None:
         cfg = _Cfg([
             {"type": "notify_device", "name": "off", "enabled": False, "options": {}},
@@ -235,6 +252,38 @@ class MqttTransportTests(unittest.TestCase):
             plugin.published_topics_for(_event("critical")),
             ["intel/events/normalized", "intel/events/high_priority"],
         )
+        # High impact with non-severe severity still targets high_priority (#58).
+        high_impact = EmergencyEvent(title="x", severity="medium", confidence=0.5,
+                                     impact_score=9)
+        self.assertIn("intel/events/high_priority",
+                      plugin.published_topics_for(high_impact))
+
+    def test_send_raises_when_disconnected(self) -> None:
+        # No client injected and no broker: send must fail, not fake success.
+        plugin = MqttTransportPlugin("bus", {"base_topic": "intel/events"})
+        plugin.start(PluginContext(bus=EventBus(), config=None, node_id="N"))
+        with self.assertRaises(RuntimeError):
+            plugin.send(_event("critical"))
+
+    def test_stop_resets_client_for_reconnect(self) -> None:
+        fake = FakeMqttClient()
+        plugin = MqttTransportPlugin("bus", {"client": fake})
+        plugin.start(PluginContext(bus=EventBus(), config=None, node_id="N"))
+        plugin.stop()
+        self.assertIsNone(plugin._client)
+
+
+class LoaderHardeningTests(unittest.TestCase):
+    def test_missing_type_returns_none(self) -> None:
+        # A name without a type is a misconfiguration, not a type.
+        self.assertIsNone(build_plugin({"name": "siren"}))
+
+    def test_nonobject_options_coerced(self) -> None:
+        plugin = build_plugin(
+            {"type": "notify_device", "name": "n", "options": "not-a-dict"}
+        )
+        self.assertIsInstance(plugin, NotifyDevicePlugin)
+        self.assertEqual(plugin.options, {})
 
 
 if __name__ == "__main__":

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -122,6 +122,22 @@ class RegistryRoutingTests(unittest.TestCase):
         registry = build_registry(cfg, node_id="NODE-A")
         self.assertEqual(registry.plugins, [])
 
+    def test_restart_does_not_double_subscribe(self) -> None:
+        cfg = _Cfg([
+            {"type": "notify_device", "name": "log",
+             "options": {"min_severity": "low", "desktop": False}},
+        ])
+        registry = build_registry(cfg, node_id="NODE-A")
+        log = registry.plugins[0]
+        registry.publish(_event("low"))
+        self.assertEqual(len(log.rendered), 1)
+        # Stop then start again (config reload / reconnect) must not leave a
+        # stale subscription that double-delivers.
+        registry.stop_all()
+        registry.start_all()
+        registry.publish(_event("low"))
+        self.assertEqual(len(log.rendered), 2)
+
     def test_inert_registry_with_no_plugins(self) -> None:
         registry = build_registry(_Cfg([]), node_id="NODE-A")
         # publish must be a no-op and never raise.
@@ -163,6 +179,24 @@ class IngestSubscriptionTests(unittest.TestCase):
         registry.subscribe_ingest(got.append)
         registry.bus.publish(TOPIC_INGEST, _event())
         self.assertEqual(len(got), 1)
+
+
+class ConfigPersistenceTests(unittest.TestCase):
+    def test_appconfig_persists_plugins(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+        from utils.config import AppConfig, load_config, save_config
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("utils.config.config_dir", return_value=Path(tmp)):
+                cfg = AppConfig(plugins=[
+                    {"type": "mqtt_transport", "name": "bus", "enabled": True,
+                     "options": {"host": "127.0.0.1"}},
+                ])
+                save_config(cfg)
+                loaded = load_config()
+                self.assertEqual(loaded.plugins, cfg.plugins)
 
 
 class LoaderTests(unittest.TestCase):

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -230,6 +230,20 @@ class ConfigPersistenceTests(unittest.TestCase):
                 loaded = load_config()
                 self.assertEqual(loaded.plugins, cfg.plugins)
 
+    def test_nonlist_plugins_in_config_coerced_to_empty(self) -> None:
+        import json
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+        from utils.config import load_config
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("utils.config.config_dir", return_value=Path(tmp)):
+                (Path(tmp) / "config.json").write_text(
+                    json.dumps({"subject": "x", "plugins": {"a": 1}}), encoding="utf-8"
+                )
+                self.assertEqual(load_config().plugins, [])
+
 
 class LoaderTests(unittest.TestCase):
     def test_resolve_builtin_and_module_path(self) -> None:

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -41,6 +41,21 @@ def _event(severity: str = "high") -> EmergencyEvent:
     )
 
 
+class PluginHealthTests(unittest.TestCase):
+    def test_success_clears_error_and_error_updates_item_count(self) -> None:
+        from plugins.base import PluginHealth
+        h = PluginHealth(name="x", kind="source")
+        h.record_success(item_count=5)
+        h.record_error("boom")  # item_count must update on failure too
+        self.assertEqual(h.last_item_count, 0)
+        self.assertIsNotNone(h.last_error_utc)
+        h.record_success(item_count=3)  # success clears error + its timestamp
+        self.assertIsNone(h.last_error)
+        self.assertIsNone(h.last_error_utc)
+        snap = h.as_dict()
+        self.assertEqual(snap["last_successful_fetch_utc"], snap["last_success_utc"])
+
+
 class EventBusTests(unittest.TestCase):
     def test_publish_delivers_to_subscribers(self) -> None:
         bus = EventBus()

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -188,6 +188,21 @@ class SourcePluginPollTests(unittest.TestCase):
         events = asyncio.run(registry.poll_sources())
         self.assertEqual(len(events), 2)
 
+    def test_poll_sources_isolates_nonlist_return(self) -> None:
+        class BadShape(SourcePlugin):
+            async def poll(self, ctx: PluginContext):
+                return None  # not a list
+
+        class GoodSource(SourcePlugin):
+            async def poll(self, ctx: PluginContext):
+                return [_event("low")]
+
+        registry = build_registry(_Cfg([]), node_id="NODE-A")
+        registry.register(BadShape("bad"))
+        registry.register(GoodSource("good"))
+        events = asyncio.run(registry.poll_sources())
+        self.assertEqual(len(events), 1)  # good plugin still collected
+
     def test_poll_sources_isolates_failures(self) -> None:
         class BadSource(SourcePlugin):
             async def poll(self, ctx: PluginContext):

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -322,6 +322,13 @@ class LoaderHardeningTests(unittest.TestCase):
         # A name without a type is a misconfiguration, not a type.
         self.assertIsNone(build_plugin({"name": "siren"}))
 
+    def test_enabled_string_false_disables(self) -> None:
+        # A user-edited "enabled": "false" must disable the plugin (bool("false")
+        # would otherwise be True).
+        self.assertIsNone(
+            build_plugin({"type": "notify_device", "name": "n", "enabled": "false"})
+        )
+
     def test_nonobject_options_coerced(self) -> None:
         plugin = build_plugin(
             {"type": "notify_device", "name": "n", "options": "not-a-dict"}

--- a/utils/config.py
+++ b/utils/config.py
@@ -203,7 +203,7 @@ def load_config() -> AppConfig:
         context_enable_historical=_coerce_bool(
             data.get("context_enable_historical", True), True
         ),
-        plugins=list(data.get("plugins", []) or []),
+        plugins=list(data["plugins"]) if isinstance(data.get("plugins"), list) else [],
     )
     cfg.news_api_key = cfg.news_api_key or os.getenv("NEWS_API_KEY")
     cfg.display_timezone = cfg.display_timezone or _load_display_timezone_from_env()

--- a/utils/config.py
+++ b/utils/config.py
@@ -72,6 +72,8 @@ class AppConfig:
     context_max_current: int = 20
     context_max_historical: int = 6
     context_enable_historical: bool = True
+    # Plugin kernel: list of {type, name, enabled, options} entries.
+    plugins: List[dict] = field(default_factory=list)
 
 
 def config_dir() -> Path:
@@ -201,6 +203,7 @@ def load_config() -> AppConfig:
         context_enable_historical=_coerce_bool(
             data.get("context_enable_historical", True), True
         ),
+        plugins=list(data.get("plugins", []) or []),
     )
     cfg.news_api_key = cfg.news_api_key or os.getenv("NEWS_API_KEY")
     cfg.display_timezone = cfg.display_timezone or _load_display_timezone_from_env()
@@ -257,6 +260,7 @@ def save_config(config: AppConfig) -> None:
         "context_max_current": config.context_max_current,
         "context_max_historical": config.context_max_historical,
         "context_enable_historical": config.context_enable_historical,
+        "plugins": config.plugins,
     }
     config_path().write_text(json.dumps(data, indent=2), encoding="utf-8")
     env_lines = []


### PR DESCRIPTION
**Phase 1 platform series — plugin kernel** · base: `main`

(Recreated after the contracts PR #72 merged; supersedes the auto-closed #73.)

Adds the plugin kernel that turns ingest, transport, device, and automation capabilities into composable plugins speaking the `EmergencyEvent` contract.

### Adds
- `plugins/base.py` — `SourcePlugin`/`TransportPlugin`/`DevicePlugin`/`SinkPlugin` + an in-process **`EventBus`** (pub/sub) that supersedes the engine's single `on_new_alert` callback; uniform `PluginHealth` telemetry (v0.8.0 shape).
- `plugins/registry.py` + `plugins/loader.py` — config-driven load (`{type, name, enabled, options}`; `type` resolves to a built-in or `module:ClassName`). Inert when no plugins configured.
- `plugins/builtin/` — **RSS source** (ingest seam), **MQTT transport** (publishes schema-valid events to `intel/events/normalized` + `intel/events/high_priority`), **notify device**.
- `tests/test_plugin_registry.py`; `paho-mqtt` dep; `docs/architecture.md`.

### Testing
Full suite green; ruff clean. Builds on the merged contracts layer. Knocks out the publish side of #57/#58/#59; advances #12/#19/#40.