### PR TITLE
ci: fix auto-tag-release startup_failure (grant required caller permissions)

### DIFF
--- a/.github/workflows/auto-tag-release-push.yml
+++ b/.github/workflows/auto-tag-release-push.yml
@@ -6,8 +6,15 @@ on:
       - main
       - master
 
+# The reusable auto-tag-release workflow declares workflow-level permissions
+# (pull-requests: read for PR-based version detection, actions: write for the
+# dispatch job). A reusable workflow cannot request permissions the caller does
+# not grant, so omitting these makes the call fail with startup_failure and no
+# release tag is created. Mirror the canonical ci-helpers caller.
 permissions:
   contents: write
+  pull-requests: read
+  actions: write
 
 jobs:
   tag:


### PR DESCRIPTION
## Problem

The `auto-tag-release-push` workflow has been failing with **`startup_failure`** on every push to `main` (including the Phase 1 release merges), so the release auto-tagging never ran — tags `0.10.0`–`0.13.0` were never created.

## Cause

The workflow calls the reusable `nikolareljin/ci-helpers/.../auto-tag-release.yml@production`, which declares workflow-level `permissions` including `pull-requests: read` (PR-based version detection) and `actions: write` (dispatch job). A reusable workflow **cannot request permissions the caller didn't grant**, and this caller only granted `contents: write` — so GitHub rejects the call at startup.

The canonical ci-helpers caller grants all three (`contents: write`, `pull-requests: read`, `actions: write`); this PR mirrors that.

## Change

Add `pull-requests: read` and `actions: write` to the caller's `permissions` block. No behavior change beyond letting the reusable workflow start.

## Note

This is pre-existing (earlier releases like `0.9.0`/`0.6.0` are also un-tagged). After merge, future `release/X.Y.Z → main` merges will auto-tag. The already-merged `0.10.0`–`0.13.0` won't be retroactively tagged by this fix — happy to create those bare-SemVer tags manually if you want.